### PR TITLE
Fix bazel build

### DIFF
--- a/tests/harness/BUILD
+++ b/tests/harness/BUILD
@@ -6,12 +6,14 @@ load("//bazel:protobuf.bzl", "cc_proto_library")
 go_proto_library(
     name = "go_default_library",
     srcs = ["harness.proto"],
+    importpath = "github.com/lyft/protoc-gen-validate/tests/harness",
     protoc = "@protobuf_bzl//:protoc",
     rules_go_repo_only_for_internal_use = "",
-    deps = [
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
-        "@com_github_golang_protobuf//protoc-gen-go/descriptor:go_default_library",
-    ],
-    importpath = "github.com/lyft/protoc-gen-validate/tests/harness",
     visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_protobuf//protoc-gen-go/descriptor:go_default_library",
+        "@com_github_golang_protobuf//ptypes/any:go_default_library",
+        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
+        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
+    ],
 )

--- a/tests/harness/cases/BUILD
+++ b/tests/harness/cases/BUILD
@@ -6,20 +6,27 @@ load(
 )
 
 pgv_go_proto_library(
-  name = "go",
-  srcs = [
-    "bool.proto",
-    "numbers.proto",
-    "strings.proto",
-    "bytes.proto",
-    "enums.proto",
-    "messages.proto",
-    "repeated.proto",
-    "maps.proto",
-    "oneofs.proto",
-    "wkt_wrappers.proto",
-    "wkt_duration.proto",
-    "wkt_timestamp.proto",
-    "wkt_any.proto",
-  ],
+    name = "go",
+    srcs = [
+        "bool.proto",
+        "bytes.proto",
+        "enums.proto",
+        "maps.proto",
+        "messages.proto",
+        "numbers.proto",
+        "oneofs.proto",
+        "repeated.proto",
+        "strings.proto",
+        "wkt_any.proto",
+        "wkt_duration.proto",
+        "wkt_timestamp.proto",
+        "wkt_wrappers.proto",
+    ],
+    rules_go_repo_only_for_internal_use = "",
+    deps = [
+        "@com_github_golang_protobuf//ptypes/any:go_default_library",
+        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
+        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
+        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
+    ],
 )

--- a/tests/harness/executor/BUILD
+++ b/tests/harness/executor/BUILD
@@ -16,10 +16,11 @@ go_library(
         "//tests/harness/go:go-harness",
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/github.com/golang/protobuf/ptypes:go_default_library",
-        "//vendor/github.com/golang/protobuf/ptypes/timestamp:go_default_library",
-        "//vendor/github.com/golang/protobuf/ptypes/duration:go_default_library",
-        "//vendor/github.com/golang/protobuf/ptypes/wrappers:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",
+        "@com_github_golang_protobuf//ptypes/any:go_default_library",
+        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
+        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
+        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
     ],
 )
 

--- a/tests/harness/executor/BUILD
+++ b/tests/harness/executor/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -24,9 +24,10 @@ go_library(
     ],
 )
 
-go_binary(
+go_test(
     name = "executor",
     importpath = "github.com/lyft/protoc-gen-validate/tests/harness/executor",
     library = ":go_default_library",
+    rundir = ".",
     visibility = ["//visibility:public"],
 )

--- a/tests/harness/executor/executor.go
+++ b/tests/harness/executor/executor.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
 )
 
@@ -52,4 +53,8 @@ func main() {
 	if failures > 0 {
 		os.Exit(1)
 	}
+}
+
+func TestEverything(test *testing.T) {
+	main()
 }


### PR DESCRIPTION
Fix the bazel build files so that `bazel build :protoc-gen-validate` builds a binary and `bazel test //tests/...` runs all the included test cases (which currently fail).