### PR TITLE
bazel: export //validate proto_library target.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,11 +8,14 @@ load("//bazel:go_proto_library.bzl", "go_proto_repositories")
 
 go_proto_repositories()
 
-git_repository(
-    name = "protobuf_bzl",
-    # v3.4.0
-    commit = "80a37e0782d2d702d52234b62dd4b9ec74fd2c95",
-    remote = "https://github.com/google/protobuf.git",
+# TODO(htuch): This can switch back to a point release http_archive at the next
+# release (> 3.4.1), we need HEAD proto_library support and
+# https://github.com/google/protobuf/pull/3761.
+http_archive(
+    name = "com_google_protobuf",
+    strip_prefix = "protobuf-c4f59dcc5c13debc572154c8f636b8a9361aacde",
+    sha256 = "5d4551193416861cb81c3bc0a428f22a6878148c57c31fb6f8f2aa4cf27ff635",
+    url = "https://github.com/google/protobuf/archive/c4f59dcc5c13debc572154c8f636b8a9361aacde.tar.gz",
 )
 
 go_rules_dependencies()

--- a/bazel/pgv_proto_library.bzl
+++ b/bazel/pgv_proto_library.bzl
@@ -5,7 +5,7 @@ def pgv_go_proto_library(name, srcs = None, deps = [], **kwargs):
     go_proto_library(name,
                      srcs,
                      deps = ["//validate:go_default_library"] + deps,
-                     protoc = "@protobuf_bzl//:protoc",
+                     protoc = "@com_google_protobuf//:protoc",
                      visibility = ["//visibility:public"],
                      validate = 1,
                      **kwargs)
@@ -13,8 +13,8 @@ def pgv_go_proto_library(name, srcs = None, deps = [], **kwargs):
 def pgv_cc_proto_library(name, srcs = None, deps = [], **kwargs):
     cc_proto_library(name,
                      srcs,
-                     protoc = "@protobuf_bzl//:protoc",
-                     default_runtime = "@protobuf_bzl//:protobuf",
+                     protoc = "@com_google_protobuf//:protoc",
+                     default_runtime = "@com_google_protobuf//:protobuf",
                      deps = ["//validate:validate_cc"] + deps,
                      visibility = ["//visibility:public"],
                      validate = 1,

--- a/tests/harness/BUILD
+++ b/tests/harness/BUILD
@@ -7,7 +7,7 @@ go_proto_library(
     name = "go_default_library",
     srcs = ["harness.proto"],
     importpath = "github.com/lyft/protoc-gen-validate/tests/harness",
-    protoc = "@protobuf_bzl//:protoc",
+    protoc = "@com_google_protobuf//:protoc",
     rules_go_repo_only_for_internal_use = "",
     visibility = ["//visibility:public"],
     deps = [

--- a/validate/BUILD
+++ b/validate/BUILD
@@ -3,19 +3,30 @@
 load("//bazel:go_proto_library.bzl", "go_proto_library")
 load("//bazel:protobuf.bzl", "cc_proto_library")
 
+proto_library(
+    name = "validate",
+    srcs = ["validate.proto"],
+    deps = [
+        "@com_google_protobuf//:descriptor_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 cc_proto_library(
-  name = "validate_cc",
-  srcs = ["validate.proto"],
-  protoc = "@protobuf_bzl//:protoc",
-  default_runtime = "@protobuf_bzl//:protobuf",
-  deps = ["@protobuf_bzl//:cc_wkt_protos"],
-  visibility = ["//visibility:public"],
+    name = "validate_cc",
+    srcs = ["validate.proto"],
+    protoc = "@com_google_protobuf//:protoc",
+    default_runtime = "@com_google_protobuf//:protobuf",
+    deps = ["@com_google_protobuf//:cc_wkt_protos"],
+    visibility = ["//visibility:public"],
 )
 
 go_proto_library(
     name = "go_default_library",
     srcs = ["validate.proto"],
-    protoc = "@protobuf_bzl//:protoc",
+    protoc = "@com_google_protobuf//:protoc",
     rules_go_repo_only_for_internal_use = "",
     deps = [
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",


### PR DESCRIPTION
This allows other Bazel consuming protos to be able to import
validate.proto in a language neutral way, needed by data-plane-api.

Also s/protobuf_bzl/com_google_protobuf/ to conform to standard
repository naming across Bazel projects.

Signed-off-by: Harvey Tuch <htuch@google.com>