### PR TITLE
bazel: link validation libraries into test executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,4 +90,4 @@ tests/harness/go/go-harness:
 	go build -o ./tests/harness/go/go-harness ./tests/harness/go
 
 .PHONY: ci
-ci: build tests kitchensink testcases harness
+ci: build tests kitchensink testcases harness bazel-harness

--- a/bazel/go_proto_library.bzl
+++ b/bazel/go_proto_library.bzl
@@ -324,13 +324,15 @@ def go_proto_library(name, srcs = None, deps = None,
       protoc_gen_go = protoc_gen_go,
       protoc_gen_validate = protoc_gen_validate,
   )
-  grpc_deps = []
+  go_lib_deps = []
   if has_services:
-    grpc_deps += [x_net_context, google_grpc]
+    go_lib_deps += [x_net_context, google_grpc]
+  if validate:
+    go_lib_deps += [_WELL_KNOWN_PTYPES]
   go_library(
       name = name,
       srcs = [":" + name + _PROTOS_SUFFIX],
-      deps = deps + grpc_deps + [golang_protobuf, _WELL_KNOWN_PTYPES],
+      deps = deps + go_lib_deps + [golang_protobuf],
       testonly = testonly,
       visibility = visibility,
       **kwargs

--- a/bazel/go_proto_library.bzl
+++ b/bazel/go_proto_library.bzl
@@ -60,6 +60,8 @@ _GO_GOOGLE_PROTOBUF = "go_google_protobuf"
 _PROTOBUF_REPO = "@com_github_golang_protobuf"
 _WELL_KNOWN_REPO = _PROTOBUF_REPO + "//ptypes/"
 
+_WELL_KNOWN_PTYPES = _PROTOBUF_REPO + "//ptypes:" + _DEFAULT_LIB
+
 def _collect_protos_import(ctx):
   """Collect the list of transitive protos and m_import_path.
 
@@ -303,6 +305,8 @@ def go_proto_library(name, srcs = None, deps = None,
 
   if not validate:
     protoc_gen_validate = None
+  else:
+    outs = outs + [s[:-len(".proto")] + ".pb.validate.go" for s in outs]
 
   _go_proto_library_gen(
       name = name + _PROTOS_SUFFIX,
@@ -326,7 +330,7 @@ def go_proto_library(name, srcs = None, deps = None,
   go_library(
       name = name,
       srcs = [":" + name + _PROTOS_SUFFIX],
-      deps = deps + grpc_deps + [golang_protobuf],
+      deps = deps + grpc_deps + [golang_protobuf, _WELL_KNOWN_PTYPES],
       testonly = testonly,
       visibility = visibility,
       **kwargs

--- a/bazel/go_proto_library.bzl
+++ b/bazel/go_proto_library.bzl
@@ -306,7 +306,7 @@ def go_proto_library(name, srcs = None, deps = None,
   if not validate:
     protoc_gen_validate = None
   else:
-    outs = outs + [s[:-len(".proto")] + ".pb.validate.go" for s in outs]
+    outs += [s[:-len(".proto")] + ".pb.validate.go" for s in outs]
 
   _go_proto_library_gen(
       name = name + _PROTOS_SUFFIX,

--- a/tests/harness/cases/BUILD
+++ b/tests/harness/cases/BUILD
@@ -22,6 +22,7 @@ pgv_go_proto_library(
         "wkt_timestamp.proto",
         "wkt_wrappers.proto",
     ],
+    importpath = "github.com/lyft/protoc-gen-validate/tests/harness/cases/go",
     rules_go_repo_only_for_internal_use = "",
     deps = [
         "@com_github_golang_protobuf//ptypes/any:go_default_library",

--- a/tests/harness/executor/BUILD
+++ b/tests/harness/executor/BUILD
@@ -30,4 +30,8 @@ go_test(
     library = ":go_default_library",
     rundir = ".",
     visibility = ["//visibility:public"],
+    deps = [
+        "//tests/harness/cases:go",
+        "//tests/harness/go:go-harness",
+    ],
 )

--- a/tests/harness/go/harness.go
+++ b/tests/harness/go/harness.go
@@ -21,13 +21,11 @@ func main() {
 	da := new(ptypes.DynamicAny)
 	checkErr(ptypes.UnmarshalAny(tc.Message, da))
 
-	if msg, ok := da.Message.(interface {
+	msg := da.Message.(interface {
 		Validate() error
-	}); ok {
-		checkValid(msg.Validate())
-	} else {
-		checkValid(nil)
-	}
+	})
+	checkValid(msg.Validate())
+
 }
 
 func checkValid(err error) {


### PR DESCRIPTION
The bazel-built test executable was executing but not succeeding because the
validation code was not getting linked in at compile-time and the test used
lazy duck-typing to validate. This patch
1. makes the test fail loudly if an input doesn't implement the correct
   interface
2. updates the bazel rule to link in the validation code
3. fixes the test code so it imports the validation code
4. modifies the CI script to also run the tests via bazel
