### PR TITLE
bazel: minor fixups for Envoy data-plane-api Go build with validate.p…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ testcases:
 
 validate/validate.pb.go:
 	# generates the proto extension in Go
-	cd validate && protoc -I . --go_out=. validate.proto
+	cd validate && protoc -I . --go_out=. validate.proto && cp github.com/lyft/protoc-gen-validate/validate/validate.pb.go .
 
 tests/harness/harness.pb.go:
 	# generates the test harness protos

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,7 @@
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    commit = "2e319588571f20fdaaf83058b690abd32f596e89",
+    commit = "4374be38e9a75ff5957c3922adb155d32086fe14",
 )
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 load("//bazel:go_proto_library.bzl", "go_proto_repositories")

--- a/validate/BUILD
+++ b/validate/BUILD
@@ -4,7 +4,7 @@ load("//bazel:go_proto_library.bzl", "go_proto_library")
 load("//bazel:protobuf.bzl", "cc_proto_library")
 
 proto_library(
-    name = "validate",
+    name = "validate_proto",
     srcs = ["validate.proto"],
     deps = [
         "@com_google_protobuf//:descriptor_proto",
@@ -28,6 +28,7 @@ go_proto_library(
     srcs = ["validate.proto"],
     protoc = "@com_google_protobuf//:protoc",
     rules_go_repo_only_for_internal_use = "",
+    ignore_go_package_option = 1,  # https://github.com/bazelbuild/rules_go/issues/323
     deps = [
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",

--- a/validate/validate.proto
+++ b/validate/validate.proto
@@ -1,6 +1,8 @@
 syntax = "proto2";
 package validate;
 
+option go_package = "github.com/lyft/protoc-gen-validate/validate";
+
 import "google/protobuf/descriptor.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";


### PR DESCRIPTION
…roto.

* Define go_package in validate.proto.

* Bumped io_bazel_rules_go SHA to match data-plane-api.

Signed-off-by: Harvey Tuch <htuch@google.com>