### PR TITLE
bazel: Python support for validate.proto.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,3 +20,15 @@ http_archive(
 
 go_rules_dependencies()
 go_register_toolchains()
+
+bind(
+    name = "six",
+    actual = "@six_archive//:six",
+)
+
+new_http_archive(
+    name = "six_archive",
+    build_file = "@com_google_protobuf//:six.BUILD",
+    sha256 = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a",
+    url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz#md5=34eed507548117b2ab523ab14b2f8b55",
+)

--- a/validate/BUILD
+++ b/validate/BUILD
@@ -1,7 +1,7 @@
 # gazelle:exclude validate.pb.go
 
 load("//bazel:go_proto_library.bzl", "go_proto_library")
-load("//bazel:protobuf.bzl", "cc_proto_library")
+load("//bazel:protobuf.bzl", "cc_proto_library", "py_proto_library")
 
 proto_library(
     name = "validate_proto",
@@ -20,6 +20,15 @@ cc_proto_library(
     protoc = "@com_google_protobuf//:protoc",
     default_runtime = "@com_google_protobuf//:protobuf",
     deps = ["@com_google_protobuf//:cc_wkt_protos"],
+    visibility = ["//visibility:public"],
+)
+
+py_proto_library(
+    name = "validate_py",
+    srcs = ["validate.proto"],
+    protoc = "@com_google_protobuf//:protoc",
+    default_runtime = "@com_google_protobuf//:protobuf_python",
+    deps = ["@com_google_protobuf//:protobuf_python"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Needed to support Python protodoc tool in data-plane-api.

Signed-off-by: Harvey Tuch <htuch@google.com>