### PR TITLE
OneOf: properly avoid naming conflicts in generated Go code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ kitchensink:
 		--go_out="${VALIDATE_IMPORT}:./go" \
 		--validate_out="lang=go:./go" \
 		`find . -name "*.proto"`
+	cd tests/kitchensink/go && go build .
 
 .PHONY: testcases
 testcases:

--- a/templates/go/register.go
+++ b/templates/go/register.go
@@ -197,8 +197,18 @@ func oneofTypeName(f pgs.Field) pgs.TypeName {
 		f.Name().PGGUpperCamelCase(),
 	))
 
-	if name == f.Type().Name() {
-		name += "_"
+	for _, enum := range f.Message().Enums() {
+		if name == enum.TypeName() {
+			name += "_"
+			break
+		}
+	}
+
+	for _, msg := range f.Message().Messages() {
+		if name == msg.TypeName() {
+			name += "_"
+			break
+		}
 	}
 
 	return name.Pointer()

--- a/tests/kitchensink/oneof.proto
+++ b/tests/kitchensink/oneof.proto
@@ -16,8 +16,14 @@ message OneOf {
         bytes bytes   = 3;
         Embed msg_req = 4 [(validate.rules).message.required = true];
         Enum  enum    = 5 [(validate.rules).enum.defined_only = true];
+
+        // ensure proper generation around potential name conflict with type
+        Embed embed        = 6;
+        string other_embed = 7;
     }
 
     message Embed {}
+    message OtherEmbed{}
     enum Enum { DEFAULT = 0; }
 }
+


### PR DESCRIPTION
This patch includes a small code fix for properly handling OneOf field wrapper struct names when they can potentially conflict with a nested enum or message.