### PR TITLE
Allow partially implemented C++ validation code

### DIFF
--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -16,30 +16,31 @@ import (
 
 func Register(tpl *template.Template) {
 	tpl.Funcs(map[string]interface{}{
-		"cmt":         pgs.C80,
-		"class":       className,
-		"accessor":    accessor,
-		"ctype":       cType,
-		"err":         err,
-		"errCause":    errCause,
-		"errIdx":      errIdx,
-		"errIdxCause": errIdxCause,
-		"lookup":      lookup,
-		"lit":         lit,
-		"isBytes":     isBytes,
-		"upper":       strings.ToUpper,
-		"byteStr":     byteStr,
-		"oneof":       oneofTypeName,
-		"quote":       quote,
-		"inType":      inType,
-		"inKey":       inKey,
-		"durLit":      durLit,
-		"durStr":      durStr,
-		"durGt":       durGt,
-		"tsLit":       tsLit,
-		"tsGt":        tsGt,
-		"tsStr":       tsStr,
-		"unwrap":      unwrap,
+		"cmt":           pgs.C80,
+		"class":         className,
+		"accessor":      accessor,
+		"ctype":         cType,
+		"err":           err,
+		"errCause":      errCause,
+		"errIdx":        errIdx,
+		"errIdxCause":   errIdxCause,
+		"lookup":        lookup,
+		"lit":           lit,
+		"isBytes":       isBytes,
+		"upper":         strings.ToUpper,
+		"byteStr":       byteStr,
+		"oneof":         oneofTypeName,
+		"quote":         quote,
+		"inType":        inType,
+		"inKey":         inKey,
+		"durLit":        durLit,
+		"durStr":        durStr,
+		"durGt":         durGt,
+		"tsLit":         tsLit,
+		"tsGt":          tsGt,
+		"tsStr":         tsStr,
+		"unwrap":        unwrap,
+		"unimplemented": failUnimplemented,
 	})
 
 	template.Must(tpl.Parse(fileTpl))
@@ -310,4 +311,8 @@ func unwrap(ctx shared.RuleContext, name string) (shared.RuleContext, error) {
 		ctx.Field.Type().Embed().Fields()[0].Name().PGGUpperCamelCase())
 
 	return ctx, nil
+}
+
+func failUnimplemented() string {
+	return "throw std::string(\"not yet implemented\");"
 }

--- a/tests/harness/cc/harness.cc
+++ b/tests/harness/cc/harness.cc
@@ -67,8 +67,15 @@ std::function<TestResult()> GetValidationCheck(const Any& msg) {
       TestResult result;                                   \
       CLS unpacked;                                        \
       msg.UnpackTo(&unpacked);                             \
-      result.set_valid(Validate(unpacked, &err_msg));      \
-      result.set_reason(std::move(err_msg));               \
+      try {                                                \
+        result.set_valid(Validate(unpacked, &err_msg));    \
+        result.set_reason(std::move(err_msg));             \
+      } catch (std::string& e) {                           \
+        /* don't fail for unimplemented validations */     \
+        result.set_valid(false);                           \
+        result.set_allowfailure(true);                     \
+        result.set_reason(e);                              \
+      }                                                    \
       return result;                                       \
     };                                                     \
   }


### PR DESCRIPTION
Instead of holding off on translating the validation code for a field type until all the cross-language issues are worked out (#22), support exceptions as a means of conveying to the calling code that a validation type is not yet implemented. This will allow the C++ validation code to move forward one constraint at a time instead of one field type at a time.