### PR TITLE
bazel: fix cross repo regression in pgv_proto_library.

### DIFF
--- a/bazel/pgv_proto_library.bzl
+++ b/bazel/pgv_proto_library.bzl
@@ -88,6 +88,9 @@ def pgv_cc_proto_library(
   native.cc_library(
       name=name,
       hdrs=gen_hdrs,
-      deps=cc_libs + deps + [":" + name + "_proto", "//validate:cc_validate"],
+      deps=cc_libs + deps + [
+          ":" + name + "_proto",
+          "@com_lyft_protoc_gen_validate//validate:cc_validate",
+      ],
       includes=includes,
       **kargs)


### PR DESCRIPTION
Need to use workspace qualified names to support pgv_proto_library use
across repos.

Signed-off-by: Harvey Tuch <htuch@google.com>