### PR TITLE
templates: C++ Duration support.

### DIFF
--- a/templates/cc/duration.go
+++ b/templates/cc/duration.go
@@ -3,88 +3,87 @@ package tpl
 const durationTpl = `{{ $f := .Field }}{{ $r := .Rules }}
 	{{ template "required" . }}
 
-	{{ if or $r.In $r.NotIn $r.Lt $r.Lte $r.Gt $r.Gte }}
-		if d := {{ accessor . }}; d != nil {
-			dur, err := ptypes.Duration(d)
-			if err != nil { return {{ errCause . "err" "value is not a valid duration" }} }
+	{{ if or $r.In $r.NotIn $r.Lt $r.Lte $r.Gt $r.Gte $r.Const }}
+	        if (!{{ hasAccessor . }}) {
+			return true;
+	        }
 
-			{{  if $r.Lt }}  lt  := {{ durLit $r.Lt }};  {{ end }}
-			{{- if $r.Lte }} lte := {{ durLit $r.Lte }}; {{ end }}
-			{{- if $r.Gt }}  gt  := {{ durLit $r.Gt }};  {{ end }}
-			{{- if $r.Gte }} gte := {{ durLit $r.Gte }}; {{ end }}
+	        const pgv::protobuf::Duration& dur = {{ accessor . }};
 
-			{{ if $r.Lt }}
-				{{ if $r.Gt }}
-					{{  if durGt $r.GetLt $r.GetGt }}
-						if dur <= gt || dur >= lt {
-							return {{ err . "value must be inside range (" (durStr $r.GetGt) ", " (durStr $r.GetLt) ")" }}
-						}
-					{{ else }}
-						if dur >= lt && dur <= gt {
-							return {{ err . "value must be outside range [" (durStr $r.GetLt) ", " (durStr $r.GetGt) "]" }}
-						}
-					{{ end }}
-				{{ else if $r.Gte }}
-					{{  if durGt $r.GetLt $r.GetGte }}
-						if dur < gte || dur >= lt {
-							return {{ err . "value must be inside range [" (durStr $r.GetGte) ", " (durStr $r.GetLt) ")" }}
-						}
-					{{ else }}
-						if dur >= lt && dur < gte {
-							return {{ err . "value must be outside range [" (durStr $r.GetLt) ", " (durStr $r.GetGte) ")" }}
-						}
-					{{ end }}
+		if (dur.nanos() > 999999999 || dur.nanos() < -999999999 ||
+		    dur.seconds() > pgv::protobuf::util::TimeUtil::kDurationMaxSeconds ||
+		    dur.seconds() < pgv::protobuf::util::TimeUtil::kDurationMinSeconds)
+	                {{ errCause . "err" "value is not a valid duration" }}
+
+		const int64_t nanos = pgv::protobuf::util::TimeUtil::DurationToNanoseconds(dur);
+
+		{{  if $r.Const }}
+			if (nanos != {{ durLit $r.Const }})
+				{{ err . "value must equal " (durStr $r.Const) }}
+		{{ end }}
+
+		{{  if $r.Lt }}  const int64_t lt  = {{ durLit $r.Lt }};  {{ end }}
+		{{- if $r.Lte }} const int64_t lte = {{ durLit $r.Lte }}; {{ end }}
+		{{- if $r.Gt }}  const int64_t gt  = {{ durLit $r.Gt }};  {{ end }}
+		{{- if $r.Gte }} const int64_t gte = {{ durLit $r.Gte }}; {{ end }}
+
+		{{ if $r.Lt }}
+			{{ if $r.Gt }}
+				{{  if durGt $r.GetLt $r.GetGt }}
+					if (nanos <= gt || nanos >= lt)
+						{{ err . "value must be inside range (" (durStr $r.GetGt) ", " (durStr $r.GetLt) ")" }}
 				{{ else }}
-					if dur >= lt {
-						return {{ err . "value must be less than " (durStr $r.GetLt) }}
-					}
+					if (nanos >= lt && nanos <= gt)
+						{{ err . "value must be outside range [" (durStr $r.GetLt) ", " (durStr $r.GetGt) "]" }}
 				{{ end }}
-			{{ else if $r.Lte }}
-				{{ if $r.Gt }}
-					{{  if durGt $r.GetLte $r.GetGt }}
-						if dur <= gt || dur > lte {
-							return {{ err . "value must be inside range (" (durStr $r.GetGt) ", " (durStr $r.GetLte) "]" }}
-						}
-					{{ else }}
-						if dur > lte && dur <= gt {
-							return {{ err . "value must be outside range (" (durStr $r.GetLte) ", " (durStr $r.GetGt) "]" }}
-						}
-					{{ end }}
-				{{ else if $r.Gte }}
-					{{ if durGt $r.GetLte $r.GetGte }}
-						if dur < gte || dur > lte {
-							return {{ err . "value must be inside range [" (durStr $r.GetGte) ", " (durStr $r.GetLte) "]" }}
-						}
-					{{ else }}
-						if dur > lte && dur < gte {
-							return {{ err . "value must be outside range (" (durStr $r.GetLte) ", " (durStr $r.GetGte) ")" }}
-						}
-					{{ end }}
-				{{ else }}
-					if dur > lte {
-						return {{ err . "value must be less than or equal to " (durStr $r.GetLte) }}
-					}
-				{{ end }}
-			{{ else if $r.Gt }}
-				if dur <= gt {
-					return {{ err . "value must be greater than " (durStr $r.GetGt) }}
-				}
 			{{ else if $r.Gte }}
-				if dur < gte {
-					return {{ err . "value must be greater than or equal to " (durStr $r.GetGte) }}
-				}
+				{{  if durGt $r.GetLt $r.GetGte }}
+					if (nanos < gte || nanos >= lt)
+						{{ err . "value must be inside range [" (durStr $r.GetGte) ", " (durStr $r.GetLt) ")" }}
+				{{ else }}
+					if (nanos >= lt && nanos < gte)
+						{{ err . "value must be outside range [" (durStr $r.GetLt) ", " (durStr $r.GetGte) ")" }}
+				{{ end }}
+			{{ else }}
+				if (nanos >= lt)
+					{{ err . "value must be less than " (durStr $r.GetLt) }}
 			{{ end }}
+		{{ else if $r.Lte }}
+			{{ if $r.Gt }}
+				{{  if durGt $r.GetLte $r.GetGt }}
+					if (nanos <= gt || nanos > lte)
+						{{ err . "value must be inside range (" (durStr $r.GetGt) ", " (durStr $r.GetLte) "]" }}
+				{{ else }}
+					if (nanos > lte && nanos <= gt)
+						{{ err . "value must be outside range (" (durStr $r.GetLte) ", " (durStr $r.GetGt) "]" }}
+				{{ end }}
+			{{ else if $r.Gte }}
+				{{ if durGt $r.GetLte $r.GetGte }}
+					if (nanos < gte || nanos > lte)
+						{{ err . "value must be inside range [" (durStr $r.GetGte) ", " (durStr $r.GetLte) "]" }}
+				{{ else }}
+					if (nanos > lte && nanos < gte)
+						{{ err . "value must be outside range (" (durStr $r.GetLte) ", " (durStr $r.GetGte) ")" }}
+				{{ end }}
+			{{ else }}
+				if (nanos > lte)
+					{{ err . "value must be less than or equal to " (durStr $r.GetLte) }}
+			{{ end }}
+		{{ else if $r.Gt }}
+			if (nanos <= gt)
+				{{ err . "value must be greater than " (durStr $r.GetGt) }}
+		{{ else if $r.Gte }}
+			if (nanos < gte)
+				{{ err . "value must be greater than or equal to " (durStr $r.GetGte) }}
+		{{ end }}
 
 
-			{{ if $r.In }}
-				if _, ok := {{ lookup $f "InLookup" }}[dur]; !ok {
-					return {{ err . "value must be in list " $r.In }}
-				}
-			{{ else if $r.NotIn }}
-				if _, ok := {{ lookup $f "NotInLookup" }}[dur]; ok {
-					return {{ err . "value must not be in list " $r.NotIn }}
-				}
-			{{ end }}
-		}
+		{{ if $r.In }}
+			if ({{ lookup $f "InLookup" }}.find(nanos) == {{ lookup $f "InLookup" }}.end())
+				{{ err . "value must be in list " $r.In }}
+		{{ else if $r.NotIn }}
+			if ({{ lookup $f "NotInLookup" }}.find(nanos) != {{ lookup $f "NotInLookup" }}.end())
+				{{ err . "value must not be in list " $r.NotIn }}
+		{{ end }}
 	{{ end }}
 `

--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -247,7 +247,7 @@ func inType(f pgs.Field, x interface{}) string {
 		case []string:
 			return "string"
 		case []*duration.Duration:
-			return "time.Duration"
+			return "uint64_t"
 		default:
 			return "UNKNOWN"
 		}
@@ -300,7 +300,7 @@ func inKey(f pgs.Field, x interface{}) string {
 
 func durLit(dur *duration.Duration) string {
 	return fmt.Sprintf(
-		"time.Duration(%d * time.Second + %d * time.Nanosecond)",
+		"%d * 1000000000LL + %d",
 		dur.GetSeconds(), dur.GetNanos())
 }
 

--- a/tests/harness/cc/harness.cc
+++ b/tests/harness/cc/harness.cc
@@ -19,6 +19,7 @@
 #include "tests/harness/cases/wkt_any.pb.h"
 #include "tests/harness/cases/wkt_any.pb.validate.h"
 #include "tests/harness/cases/wkt_duration.pb.h"
+#include "tests/harness/cases/wkt_duration.pb.validate.h"
 #include "tests/harness/cases/wkt_timestamp.pb.h"
 #include "tests/harness/cases/wkt_wrappers.pb.h"
 
@@ -95,6 +96,7 @@ std::function<TestResult()> GetValidationCheck(const Any& msg) {
   X_TESTS_HARNESS_CASES_ONEOFS(TRY_RETURN_VALIDATE_CALLABLE)
   X_TESTS_HARNESS_CASES_STRINGS(TRY_RETURN_VALIDATE_CALLABLE)
   X_TESTS_HARNESS_CASES_WKT_ANY(TRY_RETURN_VALIDATE_CALLABLE)
+  X_TESTS_HARNESS_CASES_WKT_DURATION(TRY_RETURN_VALIDATE_CALLABLE)
   // TODO(akonradi) add macros as the C++ validation code gets fleshed out for
   // more field types.
 

--- a/validate/validate.h
+++ b/validate/validate.h
@@ -2,8 +2,12 @@
 #define _VALIDATE_H
 
 #include <google/protobuf/message.h>
+#include <google/protobuf/util/time_util.h>
 
 namespace pgv {
+
+namespace protobuf = google::protobuf;
+
 namespace validate {
 
 template<class T>


### PR DESCRIPTION
This is a bit hackier than the equivalent Go support, since we don't
have ptypes.Duration to do nice things like equality and validity checking.

Instead, we treat Duration as an integer representing nanoseconds and
implement the validity constraints documented in
https://github.com/google/protobuf/blob/master/src/google/protobuf/duration.proto.

Signed-off-by: Harvey Tuch <htuch@google.com>