### PR TITLE
Validate message elements in repeated fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ tests:
 	# runs all tests against the package with race detection and coverage percentage
 	go test -race -cover
 	# tests validate proto generation
-	bazel build //validate:go_default_library && diff $$(bazel info bazel-genfiles)/validate/validate.pb.go validate/validate.pb.go
+	bazel build //validate:go_default_library \
+		&& diff $$(bazel info bazel-genfiles)/validate/validate.pb.go validate/validate.pb.go
 
 .PHONY: cover
 cover:
@@ -51,7 +52,7 @@ harness: tests/harness/harness.pb.go tests/harness/go/go-harness tests/harness/c
 .PHONY: bazel-harness
 bazel-harness:
 	# runs the test harness via bazel
-	bazel run //tests/harness/executor
+	bazel run //tests/harness/executor:executor
 
 .PHONY: kitchensink
 kitchensink:
@@ -94,6 +95,7 @@ tests/harness/cc/cc-harness: tests/harness/cc/harness.cc
 	# use bazel which knows how to pull in the C++ common proto libraries
 	bazel build //tests/harness/cc:cc-harness
 	cp bazel-bin/tests/harness/cc/cc-harness $@
+	chmod 0755 $@
 
 .PHONY: ci
 ci: lint build tests kitchensink testcases harness bazel-harness

--- a/templates/cc/repeated.go
+++ b/templates/cc/repeated.go
@@ -46,6 +46,7 @@ const repTpl = `
 	{{ if or $r.GetUnique (ne (.Elem "" "").Typ "none") }}
 		for (int i = 0; i < {{ accessor . }}.size(); i++) {
 			const {{ $typ }}& item = {{ accessor . }}.Get(i);
+			(void)item;
 
 			{{ if $r.GetUnique }}
 				auto p = {{ lookup $f "Unique" }}.emplace(const_cast<{{ $typ }}&>(item));

--- a/templates/go/repeated.go
+++ b/templates/go/repeated.go
@@ -31,8 +31,9 @@ const repTpl = `
 		{{ end -}}
 	{{ end }}
 
-	{{ if or $r.GetUnique (ne 	(.Elem "" "").Typ "none") }}
+	{{ if or $r.GetUnique (ne (.Elem "" "").Typ "none") }}
 		for idx, item := range {{ accessor . }} {
+			_, _ = idx, item
 			{{ if $r.GetUnique }}
 				if _, exists := {{ lookup $f "Unique" }}[{{ if isBytes $f.Type.Element }}string(item){{ else }}item{{ end }}]; exists {
 					return {{ errIdx . "idx" "repeated value must contain unique items" }}

--- a/templates/shared/context.go
+++ b/templates/shared/context.go
@@ -166,12 +166,12 @@ func resolveRules(typ ruleTarget, rules *validate.FieldRules) (string, proto.Mes
 	case *validate.FieldRules_Timestamp:
 		return "timestamp", r.Timestamp, false
 	case nil:
-		switch {
-		case typ.IsEmbed():
+		if ft, ok := typ.(pgs.FieldType); ok && ft.IsRepeated() {
+			return "repeated", &validate.RepeatedRules{}, false
+		} else if typ.IsEmbed() {
 			return "message", &validate.MessageRules{}, false
-		default:
-			return "none", nil, false
 		}
+		return "none", nil, false
 	default:
 		return "error", nil, false
 	}

--- a/tests/harness/cases/repeated.proto
+++ b/tests/harness/cases/repeated.proto
@@ -5,11 +5,14 @@ option go_package = "cases";
 
 import "validate/validate.proto";
 
-message RepeatedNone     { repeated int64  val = 1; }
-message Embed            { int64 val = 1; }
-message RepeatedMin      { repeated Embed val = 1 [(validate.rules).repeated.min_items = 2]; }
-message RepeatedMax      { repeated double val = 1 [(validate.rules).repeated.max_items = 3]; }
-message RepeatedMinMax   { repeated sfixed32 val = 1 [(validate.rules).repeated = {min_items: 2, max_items: 4}]; }
-message RepeatedExact    { repeated uint32 val = 1 [(validate.rules).repeated = {min_items: 3, max_items: 3}]; }
-message RepeatedUnique   { repeated string val = 1 [(validate.rules).repeated.unique = true]; }
-message RepeatedItemRule { repeated float val = 1 [(validate.rules).repeated.items.float.gt = 0]; }
+message Embed { int64 val = 1 [(validate.rules).int64.gt = 0]; }
+
+message RepeatedNone      { repeated int64  val = 1; }
+message RepeatedEmbedNone { repeated Embed val = 1; }
+message RepeatedMin       { repeated Embed val = 1 [(validate.rules).repeated.min_items = 2]; }
+message RepeatedMax       { repeated double val = 1 [(validate.rules).repeated.max_items = 3]; }
+message RepeatedMinMax    { repeated sfixed32 val = 1 [(validate.rules).repeated = {min_items: 2, max_items: 4}]; }
+message RepeatedExact     { repeated uint32 val = 1 [(validate.rules).repeated = {min_items: 3, max_items: 3}]; }
+message RepeatedUnique    { repeated string val = 1 [(validate.rules).repeated.unique = true]; }
+message RepeatedItemRule  { repeated float val = 1 [(validate.rules).repeated.items.float.gt = 0]; }
+message RepeatedEmbedSkip { repeated Embed val = 1 [(validate.rules).repeated.items.message.skip = true]; }

--- a/tests/harness/executor/BUILD
+++ b/tests/harness/executor/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
@@ -13,7 +13,6 @@ go_library(
     deps = [
         "//tests/harness:go_default_library",
         "//tests/harness/cases:go",
-        "//tests/harness/go:go-harness",
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/github.com/golang/protobuf/ptypes:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",
@@ -24,17 +23,13 @@ go_library(
     ],
 )
 
-go_test(
+go_binary(
     name = "executor",
-    data = [
-        "//tests/harness/cc:cc-harness",
-        "//tests/harness/go:go-harness",
-    ],
     importpath = "github.com/lyft/protoc-gen-validate/tests/harness/executor",
     library = ":go_default_library",
-    rundir = ".",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//tests/harness/cases:go",
-    ],
+    visibility = ["//visibility:private"],
+    data = [
+        "//tests/harness/go:go-harness",
+        "//tests/harness/cc:cc-harness",
+    ]
 )

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -20,6 +20,10 @@ type TestCase struct {
 	Valid   bool
 }
 
+type TestResult struct {
+	OK, Skipped bool
+}
+
 var TestCases []TestCase
 
 func init() {
@@ -904,9 +908,15 @@ var messageCases = []TestCase{
 var repeatedCases = []TestCase{
 	{"repeated - none - valid", &cases.RepeatedNone{[]int64{1, 2, 3}}, true},
 
-	{"repeated - min - valid", &cases.RepeatedMin{[]*cases.Embed{&cases.Embed{1}, &cases.Embed{2}, &cases.Embed{3}}}, true},
-	{"repeated - min - valid (equal)", &cases.RepeatedMin{[]*cases.Embed{&cases.Embed{1}, &cases.Embed{2}}}, true},
-	{"repeated - min - invalid", &cases.RepeatedMin{[]*cases.Embed{&cases.Embed{1}}}, false},
+	{"repeated - embed none - valid", &cases.RepeatedEmbedNone{[]*cases.Embed{{1}}}, true},
+	{"repeated - embed none - valid (nil)", &cases.RepeatedEmbedNone{}, true},
+	{"repeated - embed none - valid (empty)", &cases.RepeatedEmbedNone{[]*cases.Embed{}}, true},
+	{"repeated - embed none - invalid", &cases.RepeatedEmbedNone{[]*cases.Embed{{-1}}}, false},
+
+	{"repeated - min - valid", &cases.RepeatedMin{[]*cases.Embed{{1}, {2}, {3}}}, true},
+	{"repeated - min - valid (equal)", &cases.RepeatedMin{[]*cases.Embed{{1}, {2}}}, true},
+	{"repeated - min - invalid", &cases.RepeatedMin{[]*cases.Embed{{1}}}, false},
+	{"repeated - min - invalid (element)", &cases.RepeatedMin{[]*cases.Embed{{1}, {-1}}}, false},
 
 	{"repeated - max - valid", &cases.RepeatedMax{[]float64{1, 2}}, true},
 	{"repeated - max - valid (equal)", &cases.RepeatedMax{[]float64{1, 2, 3}}, true},
@@ -930,6 +940,9 @@ var repeatedCases = []TestCase{
 	{"repeated - items - valid", &cases.RepeatedItemRule{[]float32{1, 2, 3}}, true},
 	{"repeated - items - valid (empty)", &cases.RepeatedItemRule{[]float32{}}, true},
 	{"repeated - items - invalid", &cases.RepeatedItemRule{[]float32{1, -2, 3}}, false},
+
+	{"repeated - embed skip - valid", &cases.RepeatedEmbedSkip{[]*cases.Embed{{1}}}, true},
+	{"repeated - embed skip - valid (invalid element)", &cases.RepeatedEmbedSkip{[]*cases.Embed{{-1}}}, true},
 }
 
 var mapCases = []TestCase{

--- a/tests/harness/executor/harness.go
+++ b/tests/harness/executor/harness.go
@@ -25,6 +25,7 @@ type Harness struct {
 }
 
 func InitHarness(cmd string, args ...string) Harness {
+
 	return Harness{
 		Name: cmd,
 		Exec: initHarness(cmd, args...),


### PR DESCRIPTION
This patch addresses an issue (in both Go and C++) where messages embedded in a repeated field would not be validated unless the repeated field itself had validation rules applied. Additionally, the `skip` rule on messages embedded in repeated fields caused compilation errors due to unused variables for the elements. The current solution here still leaves the loop (which hopefully gets optimized out by the compiler); a later fix should ensure the loop is not emitted.

Finally, some cleanup to some of the bazel rules to properly run the test harness. Later on, may convert the harness to utilize the Go test framework for better portability (and limiting which test cases are executed).