### PR TITLE
Use pgv::ValidationMsg as C++ Validate() error arg

### DIFF
--- a/templates/cc/message.go
+++ b/templates/cc/message.go
@@ -8,7 +8,7 @@ const messageTpl = `
 		// skipping validation for {{ $f.Name }}
 	{{ else }}
 	{
-		string inner_err;
+		pgv::ValidationMsg inner_err;
 		if ({{ hasAccessor .}} && !pgv::validate::CheckMessage({{ accessor . }}, &inner_err)) {
 			{{ errCause . "inner_err" "embedded message failed validation" }}
 		}

--- a/templates/cc/msg.go
+++ b/templates/cc/msg.go
@@ -1,7 +1,7 @@
 package tpl
 
 const declTpl = `
-extern bool Validate(const {{ class . }}& m, string* err);
+extern bool Validate(const {{ class . }}& m, pgv::ValidationMsg* err);
 `
 
 const msgTpl = `
@@ -36,7 +36,7 @@ const msgTpl = `
 
 {{ end }}{{ end }}
 
-bool Validate(const {{ class . }}& m, string* err) {
+bool Validate(const {{ class . }}& m, pgv::ValidationMsg* err) {
 	(void)m;
 	(void)err;
 {{- if disabled . }}


### PR DESCRIPTION
These got missed in PR #44. This changes the signature of the validation
functions. This shouldn't affect calling code since pgv::ValidationMsg is an alias for
std::string.