### PR TITLE
Use named imports for Go protobuf imports

### DIFF
--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -11,8 +11,8 @@ import (
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/lyft/protoc-gen-validate/tests/harness/cases/go"
-	"github.com/lyft/protoc-gen-validate/tests/harness/cases/other_package/go"
+	cases "github.com/lyft/protoc-gen-validate/tests/harness/cases/go"
+	other_package "github.com/lyft/protoc-gen-validate/tests/harness/cases/other_package/go"
 )
 
 type TestCase struct {


### PR DESCRIPTION
The package names don't match the import paths so it's hard to tell
where `cases` and `other_package` are actually defined.