### PR TITLE
Fix patern rule in repeated field

### DIFF
--- a/templates/go/msg.go
+++ b/templates/go/msg.go
@@ -91,5 +91,11 @@ var _ error = {{ errname . }}{}
 		var {{ lookup .Field "Pattern" }} = regexp.MustCompile({{ lit .Rules.GetPattern }})
 	{{ end }}{{ end }}
 
+	{{ if has .Rules "Items"}}{{ if .Rules.Items }}
+	  {{ if .Rules.Items.GetString_ }}{{ if .Rules.Items.GetString_.Pattern }}
+		var {{ lookup .Field "Pattern" }} = regexp.MustCompile({{ lit .Rules.Items.GetString_.GetPattern }})
+	  {{ end }}{{ end }}
+	{{ end }}{{ end }}
+
 {{ end }}{{ end }}
 `


### PR DESCRIPTION
Add pattern variable declaration when repeated.items contains
string rule with pattern.

For example, if I have a message declared as follow:
```protoc
message Person {
  repeated string phone = 1 [(validate.rules).repeated.items.string.pattern = '^\\d+';
}
```
The generated go code does not contain the declaration of pattern variable `_Person_Phones_Pattern`.