### PR TITLE
Use Skylark git_repository workspace rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "com_lyft_protoc_gen_validate")
 
+load('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
+
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",


### PR DESCRIPTION
The native git_repository rule does not honor git's proxy settings
(https://github.com/bazelbuild/bazel/issues/3893), so this means
that anything that depend on protoc-gen-validate will fail when building
while behind a proxy.

Example of failing build of envoy:

```
DEBUG: /root/.cache/bazel/_bazel_root/2ca1f4ebdc59348ffdc31d97a51a98d5/external/envoy/bazel/repositories.bzl:84:5: External dep build exited with return code: 0
ERROR: /root/.cache/bazel/_bazel_root/2ca1f4ebdc59348ffdc31d97a51a98d5/external/com_lyft_protoc_gen_validate/validate/BUILD:35:1: no such package '@com_github_golang_protobuf//proto': failed to fetch com_github_golang_protobuf: # cd .; git clone https://github.com/golang/protobuf /root/.cache/bazel/_bazel_root/2ca1f4ebdc59348ffdc31d97a51a98d5/external/com_github_golang_protobuf
Cloning into '/root/.cache/bazel/_bazel_root/2ca1f4ebdc59348ffdc31d97a51a98d5/external/com_github_golang_protobuf'...
fatal: unable to access 'https://github.com/golang/protobuf/': Failed connect to github.com:443; Connection refused
2018/02/08 00:00:37 exit status 128
 and referenced by '@com_lyft_protoc_gen_validate//validate:go_default_library'
```