### PR TITLE
Update rules_go to 0.9.0

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -8,15 +8,15 @@ gazelle(
     external = "vendored",
 )
 
-go_library(
-    name = "go_default_library",
+go_binary(
+    name = "protoc-gen-validate",
     srcs = [
         "checker.go",
         "main.go",
         "module.go",
     ],
     importpath = "github.com/lyft/protoc-gen-validate",
-    visibility = ["//visibility:private"],
+    visibility = ["//visibility:public"],
     deps = [
         "//templates:go_default_library",
         "//validate:go_default_library",
@@ -26,13 +26,6 @@ go_library(
         "//vendor/github.com/golang/protobuf/ptypes/timestamp:go_default_library",
         "//vendor/github.com/lyft/protoc-gen-star:go_default_library",
     ],
-)
-
-go_binary(
-    name = "protoc-gen-validate",
-    importpath = "github.com/lyft/protoc-gen-validate",
-    library = ":go_default_library",
-    visibility = ["//visibility:public"],
 )
 
 go_google_protobuf()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,7 @@ load('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    commit = "4374be38e9a75ff5957c3922adb155d32086fe14",
+    commit = "cdaa8e35cf53ba539ebe5bf6a4a407f91a284594",
 )
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 load("//bazel:go_proto_library.bzl", "go_proto_repositories")

--- a/tests/harness/go/BUILD
+++ b/tests/harness/go/BUILD
@@ -15,8 +15,20 @@ go_library(
 )
 
 go_binary(
-    name = "go-harness",
+    name = "go-harness-binary",
     importpath = "github.com/lyft/protoc-gen-validate/tests/harness/go",
     library = ":go_default_library",
+    visibility = ["//visibility:public"],
+)
+
+# todo: pass binary location to executor
+# locations of binaries should not be depended on
+# (see https://github.com/bazelbuild/rules_go#how-do-i-access-go-binary-executables-from-go-test)
+# this is a temporary workaround to allow the tests to pass on rules_go 0.9.0
+genrule(
+    name = "go-harness",
+    srcs = [":go-harness-binary"],
+    outs = ['go-harness'],
+    cmd = "cp $(location :go-harness-binary) $@",
     visibility = ["//visibility:public"],
 )

--- a/tests/harness/go/BUILD
+++ b/tests/harness/go/BUILD
@@ -21,14 +21,10 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-# todo: pass binary location to executor
-# locations of binaries should not be depended on
-# (see https://github.com/bazelbuild/rules_go#how-do-i-access-go-binary-executables-from-go-test)
-# this is a temporary workaround to allow the tests to pass on rules_go 0.9.0
 genrule(
     name = "go-harness",
     srcs = [":go-harness-binary"],
     outs = ['go-harness'],
-    cmd = "cp $(location :go-harness-binary) $@",
+    cmd = "cp $(SRCS) $@",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This updates the version of rules_go to [0.9.0](https://github.com/bazelbuild/rules_go/releases/tag/0.9.0). The BUILD files changes were
necessary to work around a linking error that happens under 0.9.0.

The fix was based on https://github.com/bazelbuild/buildtools/issues/201, but I don't really know much about the go build chain, so I don't really know what's happening, nor do I know if there's any specific motivation behind structuring the BUILD file the way it was. I'd be happy to file a bug against rules_go if this change seems like it should unnecessary, but I figured I'd put this up in case we're okay with the workaround. 

This update also adds these deprecation warnings:
```
DEBUG: /private/var/tmp/_bazel_snowp/3bae0aee9d5211471587d3b4956c9db7/external/io_bazel_rules_go/go/private/rules/wrappers.bzl:79:5:
DEPRECATED: //vendor/github.com/lyft/protoc-gen-star:go_default_test : the library attribute on go_test is deprecated. Please migrate to embed.
```

If this gets merged I'll file an issue to track cleaning that up and do the necessary work if I find the time. 