### PR TITLE
Add tests for escape sequences in regex patterns

### DIFF
--- a/tests/harness/cases/strings.proto
+++ b/tests/harness/cases/strings.proto
@@ -5,24 +5,25 @@ option go_package = "cases";
 
 import "validate/validate.proto";
 
-message StringNone        { string val = 1; }
-message StringConst       { string val = 1 [(validate.rules).string.const = "foo"]; }
-message StringIn          { string val = 1 [(validate.rules).string = {in: ["bar", "baz"]}]; }
-message StringNotIn       { string val = 1 [(validate.rules).string = {not_in: ["fizz", "buzz"]}]; }
-message StringMinLen      { string val = 1 [(validate.rules).string.min_len = 3]; }
-message StringMaxLen      { string val = 1 [(validate.rules).string.max_len = 5]; }
-message StringMinMaxLen   { string val = 1 [(validate.rules).string = {min_len: 3, max_len: 5}]; }
-message StringMinBytes    { string val = 1 [(validate.rules).string.min_bytes = 4]; }
-message StringMaxBytes    { string val = 1 [(validate.rules).string.max_bytes = 8]; }
-message StringMinMaxBytes { string val = 1 [(validate.rules).string = {min_bytes: 4, max_bytes: 8}]; }
-message StringPattern     { string val = 1 [(validate.rules).string.pattern = "(?i)^[a-z0-9]+$"]; }
-message StringPrefix      { string val = 1 [(validate.rules).string.prefix = "foo"]; }
-message StringContains    { string val = 1 [(validate.rules).string.contains = "bar"]; }
-message StringSuffix      { string val = 1 [(validate.rules).string.suffix = "baz"]; }
-message StringEmail       { string val = 1 [(validate.rules).string.email = true]; }
-message StringHostname    { string val = 1 [(validate.rules).string.hostname = true]; }
-message StringIP          { string val = 1 [(validate.rules).string.ip = true]; }
-message StringIPv4        { string val = 1 [(validate.rules).string.ipv4 = true]; }
-message StringIPv6        { string val = 1 [(validate.rules).string.ipv6 = true]; }
-message StringURI         { string val = 1 [(validate.rules).string.uri = true]; }
-message StringURIRef      { string val = 1 [(validate.rules).string.uri_ref = true]; }
+message StringNone           { string val = 1; }
+message StringConst          { string val = 1 [(validate.rules).string.const = "foo"]; }
+message StringIn             { string val = 1 [(validate.rules).string = {in: ["bar", "baz"]}]; }
+message StringNotIn          { string val = 1 [(validate.rules).string = {not_in: ["fizz", "buzz"]}]; }
+message StringMinLen         { string val = 1 [(validate.rules).string.min_len = 3]; }
+message StringMaxLen         { string val = 1 [(validate.rules).string.max_len = 5]; }
+message StringMinMaxLen      { string val = 1 [(validate.rules).string = {min_len: 3, max_len: 5}]; }
+message StringMinBytes       { string val = 1 [(validate.rules).string.min_bytes = 4]; }
+message StringMaxBytes       { string val = 1 [(validate.rules).string.max_bytes = 8]; }
+message StringMinMaxBytes    { string val = 1 [(validate.rules).string = {min_bytes: 4, max_bytes: 8}]; }
+message StringPattern        { string val = 1 [(validate.rules).string.pattern = "(?i)^[a-z0-9]+$"]; }
+message StringPatternEscapes { string val = 1 [(validate.rules).string.pattern = "\\* \\\\ \\w"]; }
+message StringPrefix         { string val = 1 [(validate.rules).string.prefix = "foo"]; }
+message StringContains       { string val = 1 [(validate.rules).string.contains = "bar"]; }
+message StringSuffix         { string val = 1 [(validate.rules).string.suffix = "baz"]; }
+message StringEmail          { string val = 1 [(validate.rules).string.email = true]; }
+message StringHostname       { string val = 1 [(validate.rules).string.hostname = true]; }
+message StringIP             { string val = 1 [(validate.rules).string.ip = true]; }
+message StringIPv4           { string val = 1 [(validate.rules).string.ipv4 = true]; }
+message StringIPv6           { string val = 1 [(validate.rules).string.ipv6 = true]; }
+message StringURI            { string val = 1 [(validate.rules).string.uri = true]; }
+message StringURIRef         { string val = 1 [(validate.rules).string.uri_ref = true]; }

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -753,6 +753,10 @@ var stringCases = []TestCase{
 	{"string - pattern - invalid", &cases.StringPattern{Val: "!@#$%^&*()"}, false},
 	{"string - pattern - invalid (empty)", &cases.StringPattern{Val: ""}, false},
 
+	{ "string - pattern (escapes) - valid", &cases.StringPatternEscapes{Val: "* \\ x"}, true},
+	{ "string - pattern (escapes) - invalid", &cases.StringPatternEscapes{Val: "invalid"}, false},
+	{ "string - pattern (escapes) - invalid (empty)", &cases.StringPatternEscapes{Val: ""}, false},
+
 	{"string - prefix - valid", &cases.StringPrefix{Val: "foobar"}, true},
 	{"string - prefix - valid (only)", &cases.StringPrefix{Val: "foo"}, true},
 	{"string - prefix - invalid", &cases.StringPrefix{Val: "bar"}, false},


### PR DESCRIPTION
Per #68, there might be some weirdness with escapes in regex. This patch adds tests to simulate the issue, which seems to behave as expected. Will likely also add to the docs with this patch to clarify the need to escape the pattern string since protoc does not treat it as literal.

Closes #68 