### PR TITLE
templates: fix Duration C++ code generation bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,14 @@ All PGV dependencies are currently checked into the project. To test PGV, `proto
 
 - **`make harness`**: executes the test-cases against each language's test harness.
 
+### Run all tests under Bazel
+
+Ensure that your `PATH` is setup to include `protoc-gen-go` and `protoc`, then:
+
+```
+bazel run //tests/harness/executor:executor
+```
+
 ### Docker
 
 PGV comes with a [Dockerfile](/Dockerfile) for consistent development tooling and CI. The main entrypoint is `make` with `quick` as the default target. This repo should be volumed into `/go/src/github.com/lyft/protoc-gen-validate` for the proper behavior.

--- a/templates/cc/duration.go
+++ b/templates/cc/duration.go
@@ -5,86 +5,84 @@ const durationTpl = `{{ $f := .Field }}{{ $r := .Rules }}
 
 	{{ if or $r.In $r.NotIn $r.Lt $r.Lte $r.Gt $r.Gte $r.Const }}
 	    {
-	        if (!{{ hasAccessor . }}) {
-			return true;
+	        if ({{ hasAccessor . }}) {
+			const pgv::protobuf_wkt::Duration& dur = {{ accessor . }};
+
+			if (dur.nanos() > 999999999 || dur.nanos() < -999999999 ||
+			    dur.seconds() > pgv::protobuf::util::TimeUtil::kDurationMaxSeconds ||
+			    dur.seconds() < pgv::protobuf::util::TimeUtil::kDurationMinSeconds)
+				{{ errCause . "err" "value is not a valid duration" }}
+
+
+			{{  if $r.Const }}
+				if (dur != {{ durLit $r.Const }})
+					{{ err . "value must equal " (durStr $r.Const) }}
+			{{ end }}
+
+			{{  if $r.Lt }}  const pgv::protobuf_wkt::Duration lt  = {{ durLit $r.Lt }};  {{ end }}
+			{{- if $r.Lte }} const pgv::protobuf_wkt::Duration lte = {{ durLit $r.Lte }}; {{ end }}
+			{{- if $r.Gt }}  const pgv::protobuf_wkt::Duration gt  = {{ durLit $r.Gt }};  {{ end }}
+			{{- if $r.Gte }} const pgv::protobuf_wkt::Duration gte = {{ durLit $r.Gte }}; {{ end }}
+
+			{{ if $r.Lt }}
+				{{ if $r.Gt }}
+					{{  if durGt $r.GetLt $r.GetGt }}
+						if (dur <= gt || dur >= lt)
+							{{ err . "value must be inside range (" (durStr $r.GetGt) ", " (durStr $r.GetLt) ")" }}
+					{{ else }}
+						if (dur >= lt && dur <= gt)
+							{{ err . "value must be outside range [" (durStr $r.GetLt) ", " (durStr $r.GetGt) "]" }}
+					{{ end }}
+				{{ else if $r.Gte }}
+					{{  if durGt $r.GetLt $r.GetGte }}
+						if (dur < gte || dur >= lt)
+							{{ err . "value must be inside range [" (durStr $r.GetGte) ", " (durStr $r.GetLt) ")" }}
+					{{ else }}
+						if (dur >= lt && dur < gte)
+							{{ err . "value must be outside range [" (durStr $r.GetLt) ", " (durStr $r.GetGte) ")" }}
+					{{ end }}
+				{{ else }}
+					if (dur >= lt)
+						{{ err . "value must be less than " (durStr $r.GetLt) }}
+				{{ end }}
+			{{ else if $r.Lte }}
+				{{ if $r.Gt }}
+					{{  if durGt $r.GetLte $r.GetGt }}
+						if (dur <= gt || dur > lte)
+							{{ err . "value must be inside range (" (durStr $r.GetGt) ", " (durStr $r.GetLte) "]" }}
+					{{ else }}
+						if (dur > lte && dur <= gt)
+							{{ err . "value must be outside range (" (durStr $r.GetLte) ", " (durStr $r.GetGt) "]" }}
+					{{ end }}
+				{{ else if $r.Gte }}
+					{{ if durGt $r.GetLte $r.GetGte }}
+						if (dur < gte || dur > lte)
+							{{ err . "value must be inside range [" (durStr $r.GetGte) ", " (durStr $r.GetLte) "]" }}
+					{{ else }}
+						if (dur > lte && dur < gte)
+							{{ err . "value must be outside range (" (durStr $r.GetLte) ", " (durStr $r.GetGte) ")" }}
+					{{ end }}
+				{{ else }}
+					if (dur > lte)
+						{{ err . "value must be less than or equal to " (durStr $r.GetLte) }}
+				{{ end }}
+			{{ else if $r.Gt }}
+				if (dur <= gt)
+					{{ err . "value must be greater than " (durStr $r.GetGt) }}
+			{{ else if $r.Gte }}
+				if (dur < gte)
+					{{ err . "value must be greater than or equal to " (durStr $r.GetGte) }}
+			{{ end }}
+
+
+			{{ if $r.In }}
+				if ({{ lookup $f "InLookup" }}.find(dur) == {{ lookup $f "InLookup" }}.end())
+					{{ err . "value must be in list " $r.In }}
+			{{ else if $r.NotIn }}
+				if ({{ lookup $f "NotInLookup" }}.find(dur) != {{ lookup $f "NotInLookup" }}.end())
+					{{ err . "value must not be in list " $r.NotIn }}
+			{{ end }}
 	        }
-
-	        const pgv::protobuf_wkt::Duration& dur = {{ accessor . }};
-
-		if (dur.nanos() > 999999999 || dur.nanos() < -999999999 ||
-		    dur.seconds() > pgv::protobuf::util::TimeUtil::kDurationMaxSeconds ||
-		    dur.seconds() < pgv::protobuf::util::TimeUtil::kDurationMinSeconds)
-	                {{ errCause . "err" "value is not a valid duration" }}
-
-
-		{{  if $r.Const }}
-			if (dur != {{ durLit $r.Const }})
-				{{ err . "value must equal " (durStr $r.Const) }}
-		{{ end }}
-
-		{{  if $r.Lt }}  const pgv::protobuf_wkt::Duration lt  = {{ durLit $r.Lt }};  {{ end }}
-		{{- if $r.Lte }} const pgv::protobuf_wkt::Duration lte = {{ durLit $r.Lte }}; {{ end }}
-		{{- if $r.Gt }}  const pgv::protobuf_wkt::Duration gt  = {{ durLit $r.Gt }};  {{ end }}
-		{{- if $r.Gte }} const pgv::protobuf_wkt::Duration gte = {{ durLit $r.Gte }}; {{ end }}
-
-		{{ if $r.Lt }}
-			{{ if $r.Gt }}
-				{{  if durGt $r.GetLt $r.GetGt }}
-					if (dur <= gt || dur >= lt)
-						{{ err . "value must be inside range (" (durStr $r.GetGt) ", " (durStr $r.GetLt) ")" }}
-				{{ else }}
-					if (dur >= lt && dur <= gt)
-						{{ err . "value must be outside range [" (durStr $r.GetLt) ", " (durStr $r.GetGt) "]" }}
-				{{ end }}
-			{{ else if $r.Gte }}
-				{{  if durGt $r.GetLt $r.GetGte }}
-					if (dur < gte || dur >= lt)
-						{{ err . "value must be inside range [" (durStr $r.GetGte) ", " (durStr $r.GetLt) ")" }}
-				{{ else }}
-					if (dur >= lt && dur < gte)
-						{{ err . "value must be outside range [" (durStr $r.GetLt) ", " (durStr $r.GetGte) ")" }}
-				{{ end }}
-			{{ else }}
-				if (dur >= lt)
-					{{ err . "value must be less than " (durStr $r.GetLt) }}
-			{{ end }}
-		{{ else if $r.Lte }}
-			{{ if $r.Gt }}
-				{{  if durGt $r.GetLte $r.GetGt }}
-					if (dur <= gt || dur > lte)
-						{{ err . "value must be inside range (" (durStr $r.GetGt) ", " (durStr $r.GetLte) "]" }}
-				{{ else }}
-					if (dur > lte && dur <= gt)
-						{{ err . "value must be outside range (" (durStr $r.GetLte) ", " (durStr $r.GetGt) "]" }}
-				{{ end }}
-			{{ else if $r.Gte }}
-				{{ if durGt $r.GetLte $r.GetGte }}
-					if (dur < gte || dur > lte)
-						{{ err . "value must be inside range [" (durStr $r.GetGte) ", " (durStr $r.GetLte) "]" }}
-				{{ else }}
-					if (dur > lte && dur < gte)
-						{{ err . "value must be outside range (" (durStr $r.GetLte) ", " (durStr $r.GetGte) ")" }}
-				{{ end }}
-			{{ else }}
-				if (dur > lte)
-					{{ err . "value must be less than or equal to " (durStr $r.GetLte) }}
-			{{ end }}
-		{{ else if $r.Gt }}
-			if (dur <= gt)
-				{{ err . "value must be greater than " (durStr $r.GetGt) }}
-		{{ else if $r.Gte }}
-			if (dur < gte)
-				{{ err . "value must be greater than or equal to " (durStr $r.GetGte) }}
-		{{ end }}
-
-
-		{{ if $r.In }}
-			if ({{ lookup $f "InLookup" }}.find(dur) == {{ lookup $f "InLookup" }}.end())
-				{{ err . "value must be in list " $r.In }}
-		{{ else if $r.NotIn }}
-			if ({{ lookup $f "NotInLookup" }}.find(dur) != {{ lookup $f "NotInLookup" }}.end())
-				{{ err . "value must not be in list " $r.NotIn }}
-		{{ end }}
 	    }
 	{{ end }}
 `

--- a/tests/harness/cases/wkt_duration.proto
+++ b/tests/harness/cases/wkt_duration.proto
@@ -26,7 +26,7 @@ message DurationGTELTE   { google.protobuf.Duration val = 1 [(validate.rules).du
 message DurationExGTELTE { google.protobuf.Duration val = 1 [(validate.rules).duration = {lte: {seconds: 60}, gte: {seconds: 3600}}]; }
 
 // Regression for earlier bug where missing Duration field would short circuit
-// evaluationi in C++.
+// evaluation in C++.
 message DurationFieldWithOtherFields {
   google.protobuf.Duration duration_val = 1 [(validate.rules).duration.lte = {seconds: 1}];
   int32 int_val = 2 [(validate.rules).int32.gt = 16];

--- a/tests/harness/cases/wkt_duration.proto
+++ b/tests/harness/cases/wkt_duration.proto
@@ -24,3 +24,10 @@ message DurationGTLT     { google.protobuf.Duration val = 1 [(validate.rules).du
 message DurationExLTGT   { google.protobuf.Duration val = 1 [(validate.rules).duration = {lt: {}, gt: {seconds: 1}}]; }
 message DurationGTELTE   { google.protobuf.Duration val = 1 [(validate.rules).duration = {gte: {seconds: 60}, lte: {seconds: 3600}}]; }
 message DurationExGTELTE { google.protobuf.Duration val = 1 [(validate.rules).duration = {lte: {seconds: 60}, gte: {seconds: 3600}}]; }
+
+// Regression for earlier bug where missing Duration field would short circuit
+// evaluationi in C++.
+message DurationFieldWithOtherFields {
+  google.protobuf.Duration duration_val = 1 [(validate.rules).duration.lte = {seconds: 1}];
+  int32 int_val = 2 [(validate.rules).int32.gt = 16];
+}

--- a/tests/harness/cc/harness.cc
+++ b/tests/harness/cc/harness.cc
@@ -1,3 +1,4 @@
+#include <functional>
 #include <iostream>
 
 #include "validate/validate.h"

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -1122,6 +1122,7 @@ var durationCases = []TestCase{
 	{"duration - exclusive gte & lte - valid (max)", &cases.DurationExGTELTE{Val: &duration.Duration{Seconds: 3600}}, true},
 	{"duration - exclusive gte & lte - valid (min)", &cases.DurationExGTELTE{Val: &duration.Duration{Seconds: 60}}, true},
 	{"duration - exclusive gte & lte - invalid", &cases.DurationExGTELTE{Val: &duration.Duration{Seconds: 61}}, false},
+	{"duration - fields with other fields - invalid other field", &cases.DurationFieldWithOtherFields{DurationVal: nil, IntVal: 12}, false},
 }
 
 var timestampCases = []TestCase{


### PR DESCRIPTION
Previously, if the duration field was missing, it would short circuit
evaluation of following fields in the message the template was embedded
in. This triggered the server config proto fuzz tests for Envoy.

Signed-off-by: Harvey Tuch <htuch@google.com>