### PR TITLE
Upgrade bazelbuild rules_go to latest release: 0.13.0

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,12 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "gazelle", "go_binary", "go_library", "go_prefix")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//bazel:go_proto_library.bzl", "go_google_protobuf")
-
-go_prefix("github.com/lyft/protoc-gen-validate")
-
-gazelle(
-    name = "gazelle",
-    external = "vendored",
-)
 
 go_binary(
     name = "protoc-gen-validate",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,7 +9,8 @@ git_repository(
 )
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 load("//bazel:go_proto_library.bzl", "go_proto_repositories")
-
+go_rules_dependencies()
+go_register_toolchains()
 go_proto_repositories()
 
 # TODO(htuch): This can switch back to a point release http_archive at the next
@@ -21,9 +22,6 @@ http_archive(
     sha256 = "5d4551193416861cb81c3bc0a428f22a6878148c57c31fb6f8f2aa4cf27ff635",
     url = "https://github.com/google/protobuf/archive/c4f59dcc5c13debc572154c8f636b8a9361aacde.tar.gz",
 )
-
-go_rules_dependencies()
-go_register_toolchains()
 
 bind(
     name = "six",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,7 @@ load('@bazel_tools//tools/build_defs/repo:git.bzl', 'git_repository')
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    commit = "cdaa8e35cf53ba539ebe5bf6a4a407f91a284594",
+    tag = "0.13.0",
 )
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 load("//bazel:go_proto_library.bzl", "go_proto_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,20 +8,12 @@ git_repository(
     tag = "0.13.0",
 )
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
-load("//bazel:go_proto_library.bzl", "go_proto_repositories")
+
 go_rules_dependencies()
 go_register_toolchains()
-go_proto_repositories()
 
-# TODO(htuch): This can switch back to a point release http_archive at the next
-# release (> 3.4.1), we need HEAD proto_library support and
-# https://github.com/google/protobuf/pull/3761.
-http_archive(
-    name = "com_google_protobuf",
-    strip_prefix = "protobuf-c4f59dcc5c13debc572154c8f636b8a9361aacde",
-    sha256 = "5d4551193416861cb81c3bc0a428f22a6878148c57c31fb6f8f2aa4cf27ff635",
-    url = "https://github.com/google/protobuf/archive/c4f59dcc5c13debc572154c8f636b8a9361aacde.tar.gz",
-)
+load("//bazel:go_proto_library.bzl", "go_proto_repositories")
+go_proto_repositories()
 
 bind(
     name = "six",

--- a/bazel/go_proto_library.bzl
+++ b/bazel/go_proto_library.bzl
@@ -49,7 +49,8 @@ go_proto_library(
 )
 """
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_repository")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 _DEFAULT_LIB = "go_default_library"  # matching go_library
 

--- a/bazel/go_proto_library.bzl
+++ b/bazel/go_proto_library.bzl
@@ -132,10 +132,10 @@ def _go_proto_library_gen_impl(ctx):
   """Rule implementation that generates Go using protoc."""
   proto_outs, go_package_name = _check_bazel_style(ctx)
 
-  go_prefix = ctx.attr.go_prefix.go_prefix
-  if go_prefix and ctx.label.package and not go_prefix.endswith("/"):
-    go_prefix = go_prefix + "/"
-  source_go_package = "%s%s%s" % (go_prefix, ctx.label.package, go_package_name)
+  importpath = ctx.attr.importpath
+  if importpath and ctx.label.package and not importpath.endswith("/"):
+    importpath = importpath + "/"
+  source_go_package = "%s%s%s" % (importpath, ctx.label.package, go_package_name)
 
   m_imports = ["M%s=%s" % (_drop_external(f.short_path), source_go_package)
                for f in ctx.files.srcs]
@@ -220,15 +220,9 @@ _go_proto_library_gen = rule(
             cfg = "host",
         ),
         "_protos": attr.label_list(default = []),
-        "go_prefix": attr.label(
-            providers = ["go_prefix"],
-            default = Label(
-                "//:go_prefix",
-                relative_to_caller_repository = True,
-            ),
-            allow_files = False,
-            cfg = "host",
-        ),
+        "importpath": attr.string(
+	    doc = "The source import path of this library. Other libraries can import this library using this path.",
+	),
     },
     output_to_genfiles = True,
     implementation = _go_proto_library_gen_impl,


### PR DESCRIPTION
Need to upgrade to 0.13.0 to pick up bug fixes and compatibility issues. Also see https://github.com/envoyproxy/envoy/pull/3949#issuecomment-407621146