### PR TITLE
README: fix example.proto and protoc includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Developers import the PGV extension and annotate the messages and fields in thei
 ```protobuf
 syntax = "proto3";
 
+package examplepb;
+
 import "validate/validate.proto";
 
 message Person {
@@ -17,7 +19,7 @@ message Person {
   string email = 2 [(validate.rules).string.email = true];
 
   string name  = 3 [(validate.rules).string = {
-                      pattern:   "^[^\d\s]+( [^\d\s]+)*$",
+                      pattern:   "^[^[0-9]A-Za-z]+( [^[0-9]A-Za-z]+)*$",
                       max_bytes: 256,
                    }];
 
@@ -82,12 +84,13 @@ make build
 
 #### Go
 
-Go generation should occur into the same output path as the official plugin. For a proto file `example.proto`, the corresponding validation code is generated into `example.pb.validate.go`:
+Go generation should occur into the same output path as the official plugin. For a proto file `example.proto`, the corresponding validation code is generated into `../generated/example.pb.validate.go`:
 
 ```sh
 protoc \
   -I . \
   -I ${GOPATH}/src \
+  -I ${GOPATH}/src/github.com/lyft/protoc-gen-validate \
   --go_out=":../generated" \
   --validate_out="lang=go:../generated" \
   example.proto
@@ -105,6 +108,7 @@ command to generate `gogo`-compatible validation code:
 protoc \
   -I . \
   -I ${GOPATH}/src \
+  -I ${GOPATH}/src/github.com/lyft/protoc-gen-validate \
   --gogofast_out=":../generated"\
   --validate_out="lang=gogo:../generated" \ example.proto
 ```


### PR DESCRIPTION
The extra -I are needed to have the

    import "validate/validate.proto";

work -- and it needs to be imported like this because that's how the
filedescriptor is registered, see

https://github.com/lyft/protoc-gen-validate/blob/e60e7f91da4/validate/validate.pb.go#L3049

Also the proto file needs package, otherwise, you'll see

    protoc-gen-go: error:can't find object with type ..Person

And those character classes in the regex don't seem to be supported?
Using them, I ended up seeing

    example.proto:11:39: Invalid escape sequence in string literal.
    example.proto:11:41: Invalid escape sequence in string literal.
    example.proto:11:49: Invalid escape sequence in string literal.
    example.proto:11:51: Invalid escape sequence in string literal.

This should fix #56.

I'm well aware that I'm not telling you anything new -- I just thought that whoever runs into this issue could use an explanation for what they see. 😃 