### PR TITLE
Add missing #include for std::function

### DIFF
--- a/validate/validate.h
+++ b/validate/validate.h
@@ -1,6 +1,7 @@
 #ifndef _VALIDATE_H
 #define _VALIDATE_H
 
+#include <functional>
 #include <stdexcept>
 #include <string>
 #include <typeinfo>


### PR DESCRIPTION
This fixes my local build, which otherwise complains about a non-templated type "function" in namespace `std`.