### PR TITLE
Fix Bazel build by generating proto code automatically

### DIFF
--- a/bazel/pgv_proto_library.bzl
+++ b/bazel/pgv_proto_library.bzl
@@ -4,19 +4,39 @@ load(":protobuf.bzl", "cc_proto_gen_validate")
 
 def pgv_go_proto_library(name, proto = None, deps = [], **kwargs):
     go_proto_compiler(
-        name = "pgv_plugin",
+        name = "pgv_plugin_go",
         suffix = ".pb.validate.go",
         valid_archive = False,
         plugin = "//:protoc-gen-validate",
         options = ["lang=go"],
     )
 
-    go_proto_library(name = name,
-                     proto = proto,
-                     deps = ["//validate:go_default_library"] + deps,
-                     compilers = ["@io_bazel_rules_go//proto:go_proto", "pgv_plugin"],
-                     visibility = ["//visibility:public"],
-                     **kwargs)
+    go_proto_library(
+        name = name,
+        proto = proto,
+        deps = ["//validate:go_default_library"] + deps,
+        compilers = ["@io_bazel_rules_go//proto:go_proto", "pgv_plugin_go"],
+        visibility = ["//visibility:public"],
+        **kwargs
+    )
+
+def pgv_gogo_proto_library(name, proto = None, deps = [], **kwargs):
+    go_proto_compiler(
+        name = "pgv_plugin_gogo",
+        suffix = ".pb.validate.go",
+        valid_archive = False,
+        plugin = "//:protoc-gen-validate",
+        options = ["lang=gogo"],
+    )
+
+    go_proto_library(
+        name = name,
+        proto = proto,
+        deps = ["//validate:go_default_library"] + deps,
+        compilers = ["@io_bazel_rules_go//proto:gogo_proto", "pgv_plugin_gogo"],
+        visibility = ["//visibility:public"],
+        **kwargs
+    )
 
 def pgv_cc_proto_library(
         name,

--- a/tests/harness/BUILD
+++ b/tests/harness/BUILD
@@ -3,7 +3,7 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
-    name = "harness_proto_target",
+    name = "harness_proto",
     srcs = ["harness.proto"],
     deps = [
         "@com_google_protobuf//:any_proto",
@@ -12,22 +12,36 @@ proto_library(
 )
 
 go_proto_library(
-    name = "go_default_library",
-    proto = ":harness_proto_target",
-    importpath = "github.com/lyft/protoc-gen-validate/tests/harness",
+    name = "harness_go_proto",
+    importpath = "github.com/lyft/protoc-gen-validate/tests/harness/go",
+    proto = ":harness_proto",
     visibility = ["//visibility:public"],
     deps = [
-        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
         "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
         "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
+    ],
+)
+
+go_proto_library(
+    name = "harness_gogo_proto",
+    compilers = ["@io_bazel_rules_go//proto:gogo_proto"],
+    importpath = "github.com/lyft/protoc-gen-validate/tests/harness/gogo",
+    proto = ":harness_proto",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_protobuf//ptypes/any:go_default_library",
+        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
+        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
+        "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
     ],
 )
 
 cc_proto_library(
-    name = "harness_proto",
+    name = "harness_cc_proto",
     deps = [
-        ":harness_proto_target",
+        ":harness_proto",
     ],
     visibility = ["//visibility:public"],
 )

--- a/tests/harness/cases/BUILD
+++ b/tests/harness/cases/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 load(
     "//bazel:pgv_proto_library.bzl",
+    "pgv_gogo_proto_library",
     "pgv_go_proto_library",
     "pgv_cc_proto_library",
 )
@@ -48,17 +49,17 @@ pgv_go_proto_library(
     ],
 )
 
-go_library(
+pgv_gogo_proto_library(
     name = "gogo",
-    srcs = glob(["gogo/*.go"]),
-    visibility = ["//visibility:public"],
     importpath = "github.com/lyft/protoc-gen-validate/tests/harness/cases/gogo",
+    proto = ":cases_proto",
     deps = [
-        "//tests/harness/gogo:go_default_library",
         "//tests/harness/cases/other_package:gogo",
-        "//validate:go_default_library",
-        "//vendor/github.com/gogo/protobuf/proto:go_default_library",
-        "//vendor/github.com/gogo/protobuf/types:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_golang_protobuf//ptypes/any:go_default_library",
+        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
+        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
+        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
     ],
 )
 

--- a/tests/harness/cases/other_package/BUILD
+++ b/tests/harness/cases/other_package/BUILD
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load(
     "//bazel:pgv_proto_library.bzl",
     "pgv_go_proto_library",
+    "pgv_gogo_proto_library",
     "pgv_cc_proto_library",
 )
 
@@ -25,16 +26,12 @@ pgv_go_proto_library(
     ],
 )
 
-go_library(
+pgv_gogo_proto_library(
     name = "gogo",
-    srcs = glob(["gogo/*.go"]),
-    visibility = ["//visibility:public"],
     importpath = "github.com/lyft/protoc-gen-validate/tests/harness/cases/other_package/gogo",
+    proto = ":embed_proto",
     deps = [
-        "//tests/harness/gogo:go_default_library",
-        "//validate:go_default_library",
-        "//vendor/github.com/gogo/protobuf/proto:go_default_library",
-        "//vendor/github.com/gogo/protobuf/types:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
     ],
 )
 

--- a/tests/harness/cc/BUILD
+++ b/tests/harness/cc/BUILD
@@ -15,7 +15,7 @@ cc_binary(
     copts = C_OPTS,
     visibility = ["//visibility:public"],
     deps = [
-        "//tests/harness:harness_proto",
+        "//tests/harness:harness_cc_proto",
         "//tests/harness/cases:cc",
     ],
 )

--- a/tests/harness/executor/BUILD
+++ b/tests/harness/executor/BUILD
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/lyft/protoc-gen-validate/tests/harness/executor",
     visibility = ["//visibility:private"],
     deps = [
+        "//tests/harness:harness_go_proto",
         "//tests/harness/cases:go",
         "//tests/harness/cases/other_package:go",
         "//tests/harness/go:go_default_library",

--- a/tests/harness/go/BUILD
+++ b/tests/harness/go/BUILD
@@ -2,10 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["harness.pb.go"],
     importpath = "github.com/lyft/protoc-gen-validate/tests/harness/go",
     visibility = ["//visibility:public"],
     deps = [
+        "//tests/harness:harness_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes/any:go_default_library",
     ],

--- a/tests/harness/go/main/BUILD
+++ b/tests/harness/go/main/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/lyft/protoc-gen-validate/tests/harness/go/main",
     visibility = ["//visibility:private"],
     deps = [
+        "//tests/harness:harness_go_proto",
         "//tests/harness/cases:go",
         "//tests/harness/cases/other_package:go",
         "//tests/harness/go:go_default_library",

--- a/tests/harness/gogo/BUILD.bazel
+++ b/tests/harness/gogo/BUILD.bazel
@@ -2,7 +2,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["harness.pb.go"],
     importpath = "github.com/lyft/protoc-gen-validate/tests/harness/gogo",
     visibility = ["//visibility:public"],
     deps = [

--- a/tests/harness/gogo/main/BUILD.bazel
+++ b/tests/harness/gogo/main/BUILD.bazel
@@ -10,8 +10,8 @@ go_library(
         "//tests/harness/cases:gogo",
         "//tests/harness/cases/other_package:gogo",
         "//tests/harness/gogo:go_default_library",
-        "//vendor/github.com/gogo/protobuf/proto:go_default_library",
-        "//vendor/github.com/gogo/protobuf/types:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
     ],
 )
 

--- a/tests/harness/gogo/main/BUILD.bazel
+++ b/tests/harness/gogo/main/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/lyft/protoc-gen-validate/tests/harness/gogo/main",
     visibility = ["//visibility:private"],
     deps = [
+        "//tests/harness:harness_gogo_proto",
         "//tests/harness/cases:gogo",
         "//tests/harness/cases/other_package:gogo",
         "//tests/harness/gogo:go_default_library",

--- a/tests/kitchensink/BUILD
+++ b/tests/kitchensink/BUILD
@@ -12,11 +12,16 @@ load(
 proto_library(
     name = "fixed32_proto",
     srcs = ["fixed32.proto"],
+    deps = ["//validate:validate_proto"],
 )
 
 pgv_go_proto_library(
     name = "fixed32_go",
-    proto = ":fixed32_proto"
+    importpath = "github.com/lyft/protoc-gen-validate/tests/kitchensink/fixed32",
+    proto = ":fixed32_proto",
+    deps = [
+        "@com_github_golang_protobuf//ptypes:go_default_library",
+    ],
 )
 
 pgv_cc_proto_library(


### PR DESCRIPTION
The test code depends on auto-generated Go code that, if missing, will cause compilation errors. This can be generated via `make`, but doing so
1. is not hermetic
2. requires proto path variables to be set

This PR updates the Bazel rules and targets so that `bazel run //tests/harness/executor` works again and runs the full test suite. The changes are limited to BUILD files (there are no code changes) so it should only affect Bazel-based builds.