### PR TITLE
enums: properly handle enums imported from an external package/namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,8 @@ testcases: gogofast
 		--go_out="Mtests/harness/cases/other_package/embed.proto=${PACKAGE}/tests/harness/cases/other_package/go,${GO_IMPORT}:./go" \
 		--plugin=protoc-gen-gogofast=$(shell pwd)/gogofast \
 		--gogofast_out="Mtests/harness/cases/other_package/embed.proto=${PACKAGE}/tests/harness/cases/other_package/gogo,${GOGO_IMPORT}:./gogo" \
-		--validate_out="lang=go:./go" \
-		--validate_out="lang=gogo:./gogo" \
+		--validate_out="lang=go,Mtests/harness/cases/other_package/embed.proto=${PACKAGE}/tests/harness/cases/other_package/go:./go" \
+		--validate_out="lang=gogo,Mtests/harness/cases/other_package/embed.proto=${PACKAGE}/tests/harness/cases/other_package/gogo:./gogo" \
 		./*.proto
 
 tests/harness/go/harness.pb.go:

--- a/templates/cc/enum.go
+++ b/templates/cc/enum.go
@@ -6,7 +6,7 @@ const enumTpl = `
 		{{ template "in" . }}
 
 		{{ if $r.GetDefinedOnly }}
-			if (!{{ (typ $f).Element }}_IsValid({{ accessor . }})) {
+			if (!{{ package $f.Type.Enum }}::{{ (typ $f).Element }}_IsValid({{ accessor . }})) {
 				{{ err . "value must be one of the defined enum values" }}
 			}
 		{{ end }}

--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -148,7 +148,7 @@ func (fns CCFuncs) className(msg pgs.Message) string {
 	return fns.packageName(msg) + "::" + fns.classBaseName(msg)
 }
 
-func (fns CCFuncs) packageName(msg pgs.Message) string {
+func (fns CCFuncs) packageName(msg pgs.Entity) string {
 	return strings.Join(msg.Package().ProtoName().Split(), "::")
 }
 
@@ -401,4 +401,12 @@ func (fns CCFuncs) staticVarName(msg pgs.Message) string {
 
 func (fns CCFuncs) output(file pgs.File, ext string) string {
 	return fns.OutputPath(file).SetExt(ext).String()
+}
+
+func (fns CCFuncs) Type(f pgs.Field) pgsgo.TypeName {
+	if f.Type().IsEnum() {
+		return pgsgo.TypeName(pgsgo.PGGUpperCamelCase(f.Type().Enum().Name()))
+	}
+
+	return fns.Context.Type(f)
 }

--- a/templates/go/file.go
+++ b/templates/go/file.go
@@ -18,6 +18,10 @@ import (
 	"unicode/utf8"
 
 	"github.com/golang/protobuf/ptypes"
+
+	{{ range $path, $pkg := enumPackages (externalEnums .) }}
+		{{ $pkg }} "{{ $path }}"
+	{{ end }}
 )
 
 // ensure the imports are used
@@ -33,6 +37,10 @@ var (
 	_ = (*url.URL)(nil)
 	_ = (*mail.Address)(nil)
 	_ = ptypes.DynamicAny{}
+
+	{{ range (externalEnums .) }}
+		_ = {{ pkg . }}.{{ name . }}(0)
+	{{ end }}
 )
 
 {{ range .AllMessages }}

--- a/templates/gogo/file.go
+++ b/templates/gogo/file.go
@@ -18,6 +18,10 @@ import (
 	"unicode/utf8"
 
 	"github.com/gogo/protobuf/types"
+
+	{{ range $path, $pkg := enumPackages (externalEnums .) }}
+		{{ $pkg }} "{{ $path }}"
+	{{ end }}
 )
 
 // ensure the imports are used
@@ -33,6 +37,10 @@ var (
 	_ = (*url.URL)(nil)
 	_ = (*mail.Address)(nil)
 	_ = types.DynamicAny{}
+
+	{{ range (externalEnums .) }}
+		_ = {{ pkg . }}.{{ name . }}(0)
+	{{ end }}
 )
 
 {{ range .AllMessages }}

--- a/tests/harness/cases/enums.proto
+++ b/tests/harness/cases/enums.proto
@@ -4,6 +4,7 @@ package tests.harness.cases;
 option go_package = "cases";
 
 import "validate/validate.proto";
+import "tests/harness/cases/other_package/embed.proto";
 
 enum TestEnum {
     ZERO = 0;
@@ -35,4 +36,6 @@ message EnumIn      { TestEnum val = 1 [(validate.rules).enum = { in: [0, 2]}];}
 message EnumAliasIn { TestEnumAlias val = 1 [(validate.rules).enum = { in: [0, 2]}];}
 
 message EnumNotIn      { TestEnum val = 1 [(validate.rules).enum = { not_in: [1]}];}
-message EnumAliasNotIn { TestEnumAlias val = 1 [(validate.rules).enum = { not_in: [1]}];}
+message EnumAliasNotIn { TestEnumAlias val = 1 [(validate.rules).enum = { not_in: [1]}]; }
+
+message EnumExternal { other_package.Enumerated val = 1 [(validate.rules).enum.defined_only = true]; }

--- a/tests/harness/cases/other_package/embed.proto
+++ b/tests/harness/cases/other_package/embed.proto
@@ -7,3 +7,5 @@ import "validate/validate.proto";
 
 // Validate message embedding across packages.
 message Embed { int64 val = 1 [(validate.rules).int64.gt = 0]; }
+
+enum Enumerated { VALUE = 0; }

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -914,6 +914,9 @@ var enumCases = []TestCase{
 	{"enum alias - not in - valid", &cases.EnumAliasNotIn{Val: cases.TestEnumAlias_ALPHA}, true},
 	{"enum alias - not in - invalid", &cases.EnumAliasNotIn{Val: cases.TestEnumAlias_B}, false},
 	{"enum alias - not in - invalid (alias)", &cases.EnumAliasNotIn{Val: cases.TestEnumAlias_BETA}, false},
+
+	{"enum external - defined_only - valid", &cases.EnumExternal{Val: other_package.Enumerated_VALUE}, true},
+	{"enum external - defined_only - invalid", &cases.EnumExternal{Val: math.MaxInt32}, false},
 }
 
 var messageCases = []TestCase{


### PR DESCRIPTION
This patch addresses an issue around the `defined_only` rule for enums when imported from a different package. In Go (and gogo), the external package must be imported to access the defined list of values for that enum; while in C++, the IsValid function should be prefixed with the fully-qualified namespace.