### PR TITLE
enum: properly prefix validation function name

### DIFF
--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -404,9 +404,12 @@ func (fns CCFuncs) output(file pgs.File, ext string) string {
 }
 
 func (fns CCFuncs) Type(f pgs.Field) pgsgo.TypeName {
+	typ := fns.Context.Type(f)
+
 	if f.Type().IsEnum() {
-		return pgsgo.TypeName(pgsgo.PGGUpperCamelCase(f.Type().Enum().Name()))
+		parts := strings.Split(typ.String(), ".")
+		typ = pgsgo.TypeName(parts[len(parts)-1])
 	}
 
-	return fns.Context.Type(f)
+	return typ
 }

--- a/tests/harness/cases/enums.proto
+++ b/tests/harness/cases/enums.proto
@@ -38,4 +38,4 @@ message EnumAliasIn { TestEnumAlias val = 1 [(validate.rules).enum = { in: [0, 2
 message EnumNotIn      { TestEnum val = 1 [(validate.rules).enum = { not_in: [1]}];}
 message EnumAliasNotIn { TestEnumAlias val = 1 [(validate.rules).enum = { not_in: [1]}]; }
 
-message EnumExternal { other_package.Enumerated val = 1 [(validate.rules).enum.defined_only = true]; }
+message EnumExternal { other_package.Embed.Enumerated val = 1 [(validate.rules).enum.defined_only = true]; }

--- a/tests/harness/cases/other_package/embed.proto
+++ b/tests/harness/cases/other_package/embed.proto
@@ -6,6 +6,8 @@ option go_package = "other_package";
 import "validate/validate.proto";
 
 // Validate message embedding across packages.
-message Embed { int64 val = 1 [(validate.rules).int64.gt = 0]; }
+message Embed {
+    int64 val = 1 [(validate.rules).int64.gt = 0];
 
-enum Enumerated { VALUE = 0; }
+    enum Enumerated { VALUE = 0; }
+}

--- a/tests/harness/executor/cases.go
+++ b/tests/harness/executor/cases.go
@@ -915,7 +915,7 @@ var enumCases = []TestCase{
 	{"enum alias - not in - invalid", &cases.EnumAliasNotIn{Val: cases.TestEnumAlias_B}, false},
 	{"enum alias - not in - invalid (alias)", &cases.EnumAliasNotIn{Val: cases.TestEnumAlias_BETA}, false},
 
-	{"enum external - defined_only - valid", &cases.EnumExternal{Val: other_package.Enumerated_VALUE}, true},
+	{"enum external - defined_only - valid", &cases.EnumExternal{Val: other_package.Embed_VALUE}, true},
 	{"enum external - defined_only - invalid", &cases.EnumExternal{Val: math.MaxInt32}, false},
 }
 


### PR DESCRIPTION
This patch addresses a bug introduced in #110 which neglected to prefix `*_IsValid` functions with the parent message names for nested enums.