### PR TITLE
Bump Bazel go rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ ENV INSTALL_DEPS \
   software-properties-common \
   unzip \
   wget \
-  maven
+  maven \
+  patch
 RUN apt-get update \
   && apt-get install -y -q --no-install-recommends curl openjdk-8-jdk \
   && echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,8 @@ load('@bazel_tools//tools/build_defs/repo:http.bzl', 'http_archive')
 
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.15.8/rules_go-0.15.8.tar.gz",
-    sha256 = "ca79fed5b24dcc0696e1651ecdd916f7a11111283ba46ea07633a53d8e1f5199",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.0/rules_go-0.16.0.tar.gz",
+    sha256 = "ee5fe78fe417c685ecb77a0a725dc9f6040ae5beb44a0ba4ddb55453aad23a8a",
 )
 http_archive(
     name = "bazel_gazelle",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,8 @@ load('@bazel_tools//tools/build_defs/repo:http.bzl', 'http_archive')
 
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.14.0/rules_go-0.14.0.tar.gz",
-    sha256 = "5756a4ad75b3703eb68249d50e23f5d64eaf1593e886b9aa931aa6e938c4e301",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.15.8/rules_go-0.15.8.tar.gz",
+    sha256 = "ca79fed5b24dcc0696e1651ecdd916f7a11111283ba46ea07633a53d8e1f5199",
 )
 http_archive(
     name = "bazel_gazelle",


### PR DESCRIPTION
This includes fixes for a change to the Starlark API around how compiler
toolchains are detected and accessed.