### PR TITLE
Implement java ExplicitValidatorIndex

### DIFF
--- a/java/pgv-java-stub/src/main/java/com/lyft/pgv/ExplicitValidatorIndex.java
+++ b/java/pgv-java-stub/src/main/java/com/lyft/pgv/ExplicitValidatorIndex.java
@@ -22,6 +22,6 @@ public class ExplicitValidatorIndex implements ValidatorIndex {
 
     @SuppressWarnings("unchecked")
     public <T> Validator<T> validatorFor(Class clazz) {
-        return VALIDATOR_INDEX.computeIfAbsent(clazz, c -> Validator.ALWAYS_VALID);
+        return VALIDATOR_INDEX.getOrDefault(clazz, Validator.ALWAYS_VALID);
     }
 }

--- a/java/pgv-java-stub/src/main/java/com/lyft/pgv/ExplicitValidatorIndex.java
+++ b/java/pgv-java-stub/src/main/java/com/lyft/pgv/ExplicitValidatorIndex.java
@@ -1,0 +1,27 @@
+package com.lyft.pgv;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * {@code ExplicitValidatorIndex} is an explicit registry of {@link Validator} instances. If no validator is registered
+ * for {@code type}, a default {@code ALWAYS_VALID} validator will be used.
+ */
+public class ExplicitValidatorIndex implements ValidatorIndex {
+    private final ConcurrentHashMap<Class, Validator> VALIDATOR_INDEX = new ConcurrentHashMap<>();
+
+    /**
+     * Adds a {@link Validator} to the set of known validators.
+     * @param forType the type to validate
+     * @param validator the validator to apply
+     * @return this
+     */
+    public <T> ExplicitValidatorIndex add(Class<T> forType, Validator<T> validator) {
+        VALIDATOR_INDEX.put(forType, validator);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Validator<T> validatorFor(Class clazz) {
+        return VALIDATOR_INDEX.computeIfAbsent(clazz, c -> Validator.ALWAYS_VALID);
+    }
+}

--- a/java/pgv-java-stub/src/main/java/com/lyft/pgv/ReflectiveValidatorIndex.java
+++ b/java/pgv-java-stub/src/main/java/com/lyft/pgv/ReflectiveValidatorIndex.java
@@ -3,9 +3,9 @@ package com.lyft.pgv;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * {@code ReflectiveValidatorIndex} uses reflection to discover {@link Validator} implementations as needed at
- * runtime for a type. If no validator can be found for {@code type}, a default {@code ALWAYS_VALID} validator will
- * be used.
+ * {@code ReflectiveValidatorIndex} uses reflection to discover {@link Validator} implementations lazily the first
+ * time a type is validated. If no validator can be found for {@code type}, a default {@code ALWAYS_VALID} validator
+ * will be used.
  */
 public final class ReflectiveValidatorIndex implements ValidatorIndex {
     private ReflectiveValidatorIndex() {


### PR DESCRIPTION
As requested, I've added `ExplicitValidatorIndex.java` as part of #54, but I'm not sure it's needed.

Generated validators for message type fields continue to use `ReflectiveValidatorIndex`, which sort of defeats the purpose of this class. I don't see an easy way to allow users to swap out which index the generated validators use, without introducing more static global variables.

Perhaps we can postpone this class until it's requested?