### PR TITLE
Implement map.min/max keys in C++

### DIFF
--- a/templates/cc/map.go
+++ b/templates/cc/map.go
@@ -4,28 +4,34 @@ const mapTpl = `
 	{{ $f := .Field }}{{ $r := .Rules }}
 
 	{{ if $r.GetMinPairs }}
-		{{ unimplemented }}
-		{{/*
+		{
+		const auto size = {{ accessor . }}.size();
 		{{ if eq $r.GetMinPairs $r.GetMaxPairs }}
-			if len({{ accessor . }}) != {{ $r.GetMinPairs }} {
-				return {{ err . "value must contain exactly " $r.GetMinPairs " pair(s)" }}
+			if (size != {{ $r.GetMinPairs }}) {
+				{{ err . "value must contain exactly " $r.GetMinPairs " pair(s)" }}
 			}
 		{{ else if $r.MaxPairs }}
-			if l := len({{ accessor . }}); l < {{ $r.GetMinPairs }} || l > {{ $r.GetMaxPairs }} {
-			 	return {{ err . "value must contain between " $r.GetMinPairs " and " $r.GetMaxPairs " pairs, inclusive" }}
+			if (size < {{ $r.GetMinPairs }} || size > {{ $r.GetMaxPairs }}) {
+				{{ err . "value must contain between " $r.GetMinPairs " and " $r.GetMaxPairs " pairs, inclusive" }}
 			}
 		{{ else }}
-			if len({{ accessor . }}) < {{ $r.GetMinPairs }} {
-				return {{ err . "value must contain at least " $r.GetMinPairs " pair(s)" }}
+			if (size < {{ $r.GetMinPairs }}) {
+				{{ err . "value must contain at least " $r.GetMinPairs " pair(s)" }}
 			}
 		{{ end }}
+	}
 	{{ else if $r.MaxPairs }}
-		if len({{ accessor . }}) > {{ $r.GetMaxPairs }} {
-			return {{ err . "value must contain no more than " $r.GetMaxPairs " pair(s)" }}
+		{
+		const auto size = {{ accessor . }}.size();
+		if (size > {{ $r.GetMaxPairs }}) {
+			{{ err . "value must contain no more than " $r.GetMaxPairs " pair(s)" }}
 		}
+	}
 	{{ end }}
 
 	{{ if or $r.GetNoSparse (ne (.Elem "" "").Typ "none") (ne (.Key "" "").Typ "none") }}
+		{{ unimplemented }}
+		{{/*
 		for key, val := range {{ accessor . }} {
 			_ = key
 

--- a/tests/harness/cc/harness.cc
+++ b/tests/harness/cc/harness.cc
@@ -16,6 +16,7 @@
 #include "tests/harness/cases/enums.pb.h"
 #include "tests/harness/cases/enums.pb.validate.h"
 #include "tests/harness/cases/maps.pb.h"
+#include "tests/harness/cases/maps.pb.validate.h"
 #include "tests/harness/cases/messages.pb.h"
 #include "tests/harness/cases/messages.pb.validate.h"
 #include "tests/harness/cases/numbers.pb.h"
@@ -101,6 +102,7 @@ std::function<TestResult()> GetValidationCheck(const Any& msg) {
   X_TESTS_HARNESS_CASES_BOOL(TRY_RETURN_VALIDATE_CALLABLE)
   X_TESTS_HARNESS_CASES_BYTES(TRY_RETURN_VALIDATE_CALLABLE)
   X_TESTS_HARNESS_CASES_ENUMS(TRY_RETURN_VALIDATE_CALLABLE)
+  X_TESTS_HARNESS_CASES_MAPS(TRY_RETURN_VALIDATE_CALLABLE)
   X_TESTS_HARNESS_CASES_MESSAGES(TRY_RETURN_VALIDATE_CALLABLE)
   X_TESTS_HARNESS_CASES_NUMBERS(TRY_RETURN_VALIDATE_CALLABLE)
   X_TESTS_HARNESS_CASES_ONEOFS(TRY_RETURN_VALIDATE_CALLABLE)


### PR DESCRIPTION
Implements min/max pair validations in C++ and adds the map test cases to the test harness.

Progress on #130.