### PR TITLE
Prefix java pgv rule dependencies with workspace name

### DIFF
--- a/bazel/pgv_proto_library.bzl
+++ b/bazel/pgv_proto_library.bzl
@@ -96,12 +96,12 @@ def pgv_java_proto_library(
         name = name,
         srcs = [name + "_validate"],
         deps = java_deps + [
-            "//validate:validate_java",
+            "@com_lyft_protoc_gen_validate//validate:validate_java",
             "@com_google_re2j//jar",
             "@com_google_protobuf//:protobuf_java",
             "@com_google_protobuf//:protobuf_java_util",
-            "//java/pgv-java-stub/src/main/java/com/lyft/pgv",
-            "//java/pgv-java-validation/src/main/java/com/lyft/pgv",
+            "@com_lyft_protoc_gen_validate//java/pgv-java-stub/src/main/java/com/lyft/pgv",
+            "@com_lyft_protoc_gen_validate//java/pgv-java-validation/src/main/java/com/lyft/pgv",
         ],
         **kwargs
     )


### PR DESCRIPTION
When using the rule (macro) from another workspace it tries to load the dependencies from there.
This forces Bazel to look into @com_lyft_protoc_gen_validate for the relevant targets.

I am not sure the problem also exists for go and cc since I don't use these, if desirable I can add the deps there as well