### PR TITLE
Java: set correct classname for repeated enum (not)in constraint

### DIFF
--- a/templates/java/register.go
+++ b/templates/java/register.go
@@ -320,6 +320,8 @@ func (fns javaFuncs) javaTypeFor(ctx shared.RuleContext) string {
 	if t.IsRepeated() {
 		if t.ProtoType() == pgs.MessageT {
 			return fns.qualifiedName(t.Element().Embed())
+		} else if t.ProtoType() == pgs.EnumT {
+			return fns.qualifiedName(t.Element().Enum())
 		}
 	}
 


### PR DESCRIPTION
When creating a constraint like this:

    repeated SomeEnum enums = 1 [ validate.rules).repeated .items.enum = { not_in: [ 0 ] } ];

The resulting array in Java that holds the not_in values is typed like:

    private final Object[] SOME_ENUM__NOT_IN = Object[]{
        Object.forNumber(0),
    }; 

It should be:

    private final SomeEnum[] SOME_ENUM__NOT_IN = SomeEnum[]{
        SomeEnum.forNumber(0),
    }; 

After some digging the error turned out to that within a repeated, the fqn for an enum wasn't getting properly resolved. 