### PR TITLE
Update register.go to fully qualify namespaces

### DIFF
--- a/templates/cc/register.go
+++ b/templates/cc/register.go
@@ -160,7 +160,7 @@ func (fns CCFuncs) className(ent childEntity) string {
 }
 
 func (fns CCFuncs) packageName(msg pgs.Entity) string {
-	return strings.Join(msg.Package().ProtoName().Split(), "::")
+	return "::" + strings.Join(msg.Package().ProtoName().Split(), "::")
 }
 
 func (fns CCFuncs) quote(s interface {


### PR DESCRIPTION
The packageName function now returns a fully-qualified prefix. When generating C++ names, full namespace qualification will avoid ambiguity in namespace resolution.